### PR TITLE
modified deploy_tools for python3 and added cleanup

### DIFF
--- a/BostonData/deploy_tools.py
+++ b/BostonData/deploy_tools.py
@@ -2,16 +2,19 @@
 Tools to package and deploy the lambda function for Boston Data app
 '''
 
+from __future__ import print_function
 import argparse
 import os
 import pip
+import shutil
 import zipfile
 
+LAMBDA_FUNCTION_DIR = os.path.join(os.getcwd(), 'lambda_function')
 
 def zip_lambda_function_directory():
     zip_file_name = "lambda_function.zip"
     zip_file = zipfile.ZipFile(zip_file_name, 'w')
-    os.chdir(os.path.join(os.getcwd(), 'lambda_function'))
+    os.chdir(LAMBDA_FUNCTION_DIR)
     for root, dirs, files in os.walk('.'):
         for f in files:
             zip_file.write(os.path.join(root, f))
@@ -23,18 +26,32 @@ def install_pip_dependencies():
     install_args = ["install", "-r", requirements_path, "-t" "lambda_function"]
     pip.main(install_args)
 
+def cleanup():
+    """
+    Removes everything except lambda_function.py and requirements.txt
+    from the lambda_function directory.
+    """
+    keep_files = ['requirements.txt', 'lambda_function.py']
+    for root, dirs, files in os.walk(LAMBDA_FUNCTION_DIR):
+        for name in files:
+            if name not in keep_files:
+                os.remove(os.path.join(root, name))
+        for name in dirs:
+            shutil.rmtree(os.path.join(root, name))
+
 
 def package_lambda_function():
-    print "Packaging lambda_function into a deployable zip file...\n"
+    print("Packaging lambda_function into a deployable zip file...\n")
     install_pip_dependencies()
     zip_lambda_function_directory()
+    cleanup()
 
 
 def main():
     parser = argparse.ArgumentParser(description="Tools to " +
         "package and deploy the lambda function for Boston Data app")
 
-    parser.add_argument('-p', '--package', help="Creates a zip file " + 
+    parser.add_argument('-p', '--package', help="Creates a zip file " +
         "that can be uploaded as an Amazon lambda function",
         action='store_true')
 
@@ -43,7 +60,7 @@ def main():
     if args.package:
         package_lambda_function()
     else:
-        print "No known option selected"
+        print("No known option selected")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
A couple of changes to the deploy_tools.py script:
- Modified print statements for python3 and added __future__ import to maintain 2.7 functionality.
- Added a cleanup function and made it part of the packaging function. Now, after installing all the dependencies and creating the .zip file, all the dependencies are removed. This isn't really necessary, but it keeps the directory clean.

