### PR TITLE
Updates to deploy_tools.py

### DIFF
--- a/BostonData/deploy_tools.py
+++ b/BostonData/deploy_tools.py
@@ -32,13 +32,14 @@ def cleanup(keep_files):
     lambda_function directory.
     """
     print("Cleaning up temporary files/directories...")
-    for root, dirs, files in os.walk(LAMBDA_FUNCTION_DIR):
-        for name in files:
-            if name not in keep_files:
-                os.remove(os.path.join(root, name))
-        for name in dirs:
-            if name not in keep_files:
-                shutil.rmtree(os.path.join(root, name))
+    dir_contents = os.listdir(LAMBDA_FUNCTION_DIR)
+    for item in dir_contents:
+        if os.path.isfile(os.path.join(LAMBDA_FUNCTION_DIR, item)):
+            if item not in keep_files:
+                os.remove(os.path.join(LAMBDA_FUNCTION_DIR, item))
+        if os.path.isdir(os.path.join(LAMBDA_FUNCTION_DIR, item)):
+            if item not in keep_files:
+                shutil.rmtree(os.path.join(LAMBDA_FUNCTION_DIR, item))
     print("Cleanup complete.")
 
 def package_lambda_function():

--- a/BostonData/deploy_tools.py
+++ b/BostonData/deploy_tools.py
@@ -2,6 +2,7 @@
 Tools to package and deploy the lambda function for Boston Data app
 '''
 
+from __future__ import print_function
 import argparse
 import os
 import pip
@@ -25,7 +26,7 @@ def install_pip_dependencies():
 
 
 def package_lambda_function():
-    print "Packaging lambda_function into a deployable zip file...\n"
+    print("Packaging lambda_function into a deployable zip file...\n")
     install_pip_dependencies()
     zip_lambda_function_directory()
 
@@ -34,7 +35,7 @@ def main():
     parser = argparse.ArgumentParser(description="Tools to " +
         "package and deploy the lambda function for Boston Data app")
 
-    parser.add_argument('-p', '--package', help="Creates a zip file " + 
+    parser.add_argument('-p', '--package', help="Creates a zip file " +
         "that can be uploaded as an Amazon lambda function",
         action='store_true')
 
@@ -43,7 +44,7 @@ def main():
     if args.package:
         package_lambda_function()
     else:
-        print "No known option selected"
+        print("No known option selected")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
I've updated the script to be python3-friendly (should still work in python2 with __future__ import).

I've also added a cleanup function and incorporated it into the package_lambda_function function. Now this function generates a list of the files/directories inside lambda_function and uses that to remove all the temporarily-installed libraries after the zip file is generated.