### PR TITLE
Answer original request if we ask for the users address

### DIFF
--- a/BostonData/lambda_function/alexa_constants.py
+++ b/BostonData/lambda_function/alexa_constants.py
@@ -1,3 +1,4 @@
 """Constants used across Alexa intents"""
 
 CURRENT_ADDRESS_KEY = "currentAddress"
+ADDRESS_PROMPTED_FROM_INTENT = "addressPromptedFromIntent"

--- a/BostonData/lambda_function/snow_parking_intent.py
+++ b/BostonData/lambda_function/snow_parking_intent.py
@@ -42,11 +42,7 @@ def get_snow_emergency_parking_intent(intent, session):
         session_attributes = session.get('attributes', {})
         should_end_session = True
     else:
-        session_attributes = session.get('attributes', {})
-        speech_output = "I'm not sure what your address is. " \
-                        "You can tell me your address by saying, " \
-                        "my address is 123 Main St., apartment 3."
-        should_end_session = False
+        print("Error: Called snow_parking_intent with no address")
 
     # Setting reprompt_text to None signifies that we do not want to reprompt
     # the user. If the user does not respond or says something that is not

--- a/BostonData/lambda_function/trash_intent.py
+++ b/BostonData/lambda_function/trash_intent.py
@@ -43,11 +43,7 @@ def get_trash_day_info(intent, session):
         session_attributes = session.get('attributes', {})
         should_end_session = True
     else:
-        session_attributes = session.get('attributes', {})
-        speech_output = "I'm not sure what your address is. " \
-                        "You can tell me your address by saying, " \
-                        "my address is 123 Main St., apartment 3."
-        should_end_session = False
+        print("Error: Called snow_parking_intent with no address")
 
     # Setting reprompt_text to None signifies that we do not want to reprompt
     # the user. If the user does not respond or says something that is not


### PR DESCRIPTION
Implements #28 

In order to answer certain requests (like trash day) we need the users address. If we ask for the user to provide the address, just answer the original request so the user doesn't have to re-answer.

This works by storing the original request in the session data under a new key "addressPromptedFromIntent". If the user triggers a ```SetAddressIntent```, we check this key at the conclusion. If the key exists, we trigger the original intent instead of returning immediately. 
  