### PR TITLE
Update trash day endpoint info to use ReCollect API.

### DIFF
--- a/BostonData/lambda_function/custom_errors.py
+++ b/BostonData/lambda_function/custom_errors.py
@@ -1,0 +1,11 @@
+""" Custom error types for My City app"""
+
+
+class InvalidAddressError(Exception):
+    """Error raised for issues with provided address"""
+    pass
+
+
+class BadAPIResponse(Exception):
+    """Error for bad responses from external APIs"""
+    pass

--- a/BostonData/lambda_function/trash_intent.py
+++ b/BostonData/lambda_function/trash_intent.py
@@ -28,13 +28,11 @@ def get_trash_day_info(intent, session):
         address = str(a['house']) + " " + str(a['street_name'])
 
         try:
-            trash_days, recycle_days = get_trash_and_recycling_days(address)
+            trash_days = get_trash_and_recycling_days(address)
             trash_days_speech = build_speech_from_list_of_days(trash_days)
-            recycle_days_speech = build_speech_from_list_of_days(recycle_days)
 
-            speech_output = "Trash is picked up on {}. " \
-                            "Recycling is picked up on {}"\
-                .format(trash_days_speech, recycle_days_speech)
+            speech_output = "Trash and recycling is picked up on {}."\
+                .format(trash_days_speech)
 
         except InvalidAddressError:
             speech_output = "I can't seem to find {}. Try another address"\
@@ -56,10 +54,11 @@ def get_trash_day_info(intent, session):
 
 def get_trash_and_recycling_days(address):
     """
-    Determines the trash and recycling days for the provided address
+    Determines the trash and recycling days for the provided address.
+    These are on the same day, so only one array of days will be returned.
 
     :param address: String of address to find trash day for
-    :return: arrays containing next trash and recycling days
+    :return: array containing next trash and recycling days
     """
 
     api_params = get_address_api_info(address)
@@ -70,9 +69,9 @@ def get_trash_and_recycling_days(address):
     if not trash_data:
         raise BadAPIResponse
 
-    trash_days, recycling_days = get_trash_days_from_trash_data(trash_data)
+    trash_and_recycling_days = get_trash_days_from_trash_data(trash_data)
 
-    return trash_days, recycling_days
+    return trash_and_recycling_days
 
 
 def get_address_api_info(address):
@@ -138,7 +137,7 @@ def get_trash_days_from_trash_data(trash_data):
     days.
 
     :param trash_data: Trash data provided from ReCollect API
-    :return: Two arrays, with trash days and recycling days
+    :return: An array containing days trash and recycling are picked up
     """
 
     try:
@@ -148,7 +147,7 @@ def get_trash_days_from_trash_data(trash_data):
         # ReCollect API returned an unexpected JSON format
         raise BadAPIResponse
 
-    return trash_days, trash_days
+    return trash_days
 
 
 def build_speech_from_list_of_days(days):

--- a/BostonData/lambda_function/trash_intent.py
+++ b/BostonData/lambda_function/trash_intent.py
@@ -3,6 +3,7 @@ Functions for Alexa responses related to trash day
 """
 
 from alexa_utilities import build_response, build_speechlet_response
+from custom_errors import InvalidAddressError, BadAPIResponse
 from streetaddress import StreetAddressParser
 import requests
 import alexa_constants
@@ -26,19 +27,20 @@ def get_trash_day_info(intent, session):
         # the same street address
         address = str(a['house']) + " " + str(a['street_name'])
 
-        # rest call to data.boston.gov for trash/recycle information
-        url = 'https://data.boston.gov/api/action/datastore_search?' + \
-              'resource_id=fee8ee07-b8b5-4ee5-b540-5162590ba5c1&q=' + \
-              '{{"Address":"{}"}}'.format(address)
-        resp = requests.get(url).json()
-        print("RESPONSE FROM DATA.BOSTON.GOV: " + str(resp))
+        try:
+            trash_days, recycle_days = get_trash_and_recycling_days(address)
+            trash_days_speech = build_speech_from_list_of_days(trash_days)
+            recycle_days_speech = build_speech_from_list_of_days(recycle_days)
 
-        # format script of response
-        record = resp['result']['records'][0]
-        speech_output = "Trash is picked up on the following days, " + \
-            ", ".join(parse_days(record['Trash'])) + \
-            ". Recycling is picked up on the following days, " + \
-            " ,".join(parse_days(record['Recycling']))
+            speech_output = "Trash is picked up on {}. " \
+                            "Recycling is picked up on {}"\
+                .format(trash_days_speech, recycle_days_speech)
+
+        except InvalidAddressError:
+            speech_output = "I can't seem to find {}. Try another address"\
+               .format(address)
+        except BadAPIResponse:
+            speech_output = "Hmm something went wrong. Maybe try again?"
 
         session_attributes = session.get('attributes', {})
         should_end_session = True
@@ -52,22 +54,119 @@ def get_trash_day_info(intent, session):
         intent['name'], speech_output, reprompt_text, should_end_session))
 
 
-def parse_days(days):
+def get_trash_and_recycling_days(address):
     """
-    Converts the string of day initials in the JSON response to the trash
-    day calendar API to a list of days.
+    Determines the trash and recycling days for the provided address
+
+    :param address: String of address to find trash day for
+    :return: arrays containing next trash and recycling days
     """
-    result = []
-    for i in range(len(days)):
-        if days[i] == 'T':
-            if i < len(days) - 1 and days[i+1] == 'H':
-                result.append('Thursday')
-            else:
-                result.append('Tuesday')
-        if days[i] == 'M':
-            result.append('Monday')
-        if days[i] == 'W':
-            result.append('Wednesday')
-        if days[i] == 'F':
-            result.append('Friday')
-    return result
+
+    api_params = get_address_api_info(address)
+    if not api_params:
+        raise InvalidAddressError
+
+    trash_data = get_trash_day_data(api_params)
+    if not trash_data:
+        raise BadAPIResponse
+
+    trash_days, recycling_days = get_trash_days_from_trash_data(trash_data)
+
+    return trash_days, recycling_days
+
+
+def get_address_api_info(address):
+    """
+    Gets the parameters required for the ReCollect API call
+
+    :param address: Address to get parameters for
+    :return: JSON object containing API parameters with format:
+
+    {
+        'area_name': value,
+        'parcel_id': value,
+        'service_id': value,
+        'place_id': value,
+        'area_id': value,
+        'name': value
+    }
+
+    """
+
+    base_url = "https://recollect.net/api/areas/" \
+               "Boston/services/310/address-suggest"
+    url_params = {'q': address, 'locale': 'en-US'}
+    request_result = requests.get(base_url, url_params)
+
+    if request_result.status_code != requests.codes.ok:
+        print("Error getting ReCollect API info. Got response: {}"
+              .format(request_result.status_code))
+        return {}
+
+    if not request_result.json():
+        return {}
+
+    return request_result.json()[0]
+
+
+def get_trash_day_data(api_parameters):
+    """
+    Gets the trash day data from ReCollect using the provided API parameters
+
+    :param api_parameters: Parameters for ReCollect API
+    :return: JSON object containing all trash data
+    """
+
+    # Rename the default API parameter "name" to "formatted_address"
+    if "name" in api_parameters:
+        api_parameters["formatted_address"] = api_parameters.pop("name")
+
+    base_url = "https://recollect.net/api/places"
+    request_result = requests.get(base_url, api_parameters)
+
+    if request_result.status_code != requests.codes.ok:
+        print("Error getting trash info from ReCollect API info. "
+              "Got response: {}".format(request_result.status_code))
+        return {}
+
+    return request_result.json()
+
+
+def get_trash_days_from_trash_data(trash_data):
+    """
+    Parse trash data from ReCollect service and return the trash and recycling
+    days.
+
+    :param trash_data: Trash data provided from ReCollect API
+    :return: Two arrays, with trash days and recycling days
+    """
+
+    try:
+        trash_days_string = trash_data["next_event"]["zone"]["title"]
+        trash_days = trash_days_string.replace('&', '').split()
+    except KeyError:
+        # ReCollect API returned an unexpected JSON format
+        raise BadAPIResponse
+
+    return trash_days, trash_days
+
+
+def build_speech_from_list_of_days(days):
+    """
+    Converts a list of days into proper speech, such as adding the word 'and'
+    before the last item.
+    :param days: String array of days
+    :return: Speech representing the provided days
+    """
+    if len(days) == 0:
+        raise BadAPIResponse
+
+    if len(days) == 1:
+        return days[0]
+    elif len(days) == 2:
+        speech_output = " and ".join(days)
+    else:
+        speech_output = ", ".join(days[0:-1])
+        speech_output += ", and {}".format(days[-1])
+
+    return speech_output


### PR DESCRIPTION
Resolves #39 

City of Boston informed us that the Boston Data site is not the most reliable source for trash day information. This PR updates our app to get data from the ReCollect API which powers the City of Boston website. 

Also adds a new file for containing custom errors to make raised errors more readable.