### PR TITLE
Rename mcd instance to corresponding Request and Response instances

### DIFF
--- a/mycity/mycity/intents/get_alerts_intent.py
+++ b/mycity/mycity/intents/get_alerts_intent.py
@@ -42,7 +42,7 @@ def get_alerts_intent(mycity_request, mycity_response):
     """
     print(
         '[method: get_alerts_intent]',
-        'MyCityDataModel received:\n',
+        'MyCityRequestDataModel received:\n',
         str(mycity_request)
     )
 

--- a/mycity/mycity/intents/get_alerts_intent.py
+++ b/mycity/mycity/intents/get_alerts_intent.py
@@ -32,14 +32,18 @@ class Services(Enum):
     ALERT_HEADER = 'Alert header'
     
 
-def get_alerts_intent(mcd):
+def get_alerts_intent(mycity_request, mycity_response):
     """
     Generate response object with information about citywide alerts
+
+    :param mycity_request: MyCityRequestModel object
+    :param mycity_response: MyCityResponseModel object
+    :return: MyCityResponseModel object
     """
     print(
         '[method: get_alerts_intent]',
         'MyCityDataModel received:\n',
-        str(mcd)
+        str(mycity_request)
     )
 
     alerts = get_alerts()
@@ -47,10 +51,12 @@ def get_alerts_intent(mcd):
     alerts = prune_normal_responses(alerts)
     print("[dictionary after pruning]:\n" + str(alerts))
 
-    mcd.reprompt_text = None
-    mcd.output_speech = alerts_to_speech_output(alerts)
-    mcd.should_end_session = True   # leave this as True for right now
-    return mcd
+    mycity_response.session_attributes = mycity_request.session_attributes
+    mycity_response.card_title = mycity_request.intent_name
+    mycity_response.reprompt_text = None
+    mycity_response.output_speech = alerts_to_speech_output(alerts)
+    mycity_response.should_end_session = True   # leave this as True for right now
+    return mycity_response
 
 
 def alerts_to_speech_output(alerts):

--- a/mycity/mycity/intents/get_alerts_intent.py
+++ b/mycity/mycity/intents/get_alerts_intent.py
@@ -19,7 +19,7 @@ and street cleaning is running on a normal schedule."
 from bs4 import BeautifulSoup
 from urllib import request
 from enum import Enum
-
+from mycity.mycity_response_data_model import MyCityResponseDataModel
 
 class Services(Enum):
     STREET_CLEANING = 'Street Cleaning'
@@ -32,7 +32,7 @@ class Services(Enum):
     ALERT_HEADER = 'Alert header'
     
 
-def get_alerts_intent(mycity_request, mycity_response):
+def get_alerts_intent(mycity_request):
     """
     Generate response object with information about citywide alerts
 
@@ -46,6 +46,7 @@ def get_alerts_intent(mycity_request, mycity_response):
         str(mycity_request)
     )
 
+    mycity_response = MyCityResponseDataModel()
     alerts = get_alerts()
     print("[dictionary with alerts scraped from boston.gov]:\n" + str(alerts))
     alerts = prune_normal_responses(alerts)

--- a/mycity/mycity/intents/snow_parking_intent.py
+++ b/mycity/mycity/intents/snow_parking_intent.py
@@ -20,7 +20,7 @@ BOSTON_DATA_PARKING_ADDRESS_INDEX = 9
 
 def get_snow_emergency_parking_intent(mycity_request, mycity_response):
     """
-    Populate MyCityDataModel with snow emergency parking response information.
+    Populate MyCityResponseDataModel with snow emergency parking response information.
 
     :param mycity_request: MyCityRequestModel object
     :param mycity_response: MyCityResponseModel object
@@ -28,7 +28,7 @@ def get_snow_emergency_parking_intent(mycity_request, mycity_response):
     """
     print(
         '[method: get_snow_emergency_parking_intent]',
-        'MyCityDataModel received:',
+        'MyCityRequestDataModel received:',
         str(mycity_request)
     )
 
@@ -68,12 +68,12 @@ def _build_origin_address(mycity_request):
     Builds an address from an Alexa session. Assumes city is Boston if not
     specified
 
-    :param mycity_request: MyCityDataModel object
+    :param mycity_request: MyCityRequestDataModel object
     :return: String containing full address
     """
     print(
         '[method: _build_origin_address]',
-        'MyCityDataModel received:',
+        'MyCityRequestDataModel received:',
         str(mycity_request)
     )
     # @todo: Repeated code -- look into using same code here and in trash intent

--- a/mycity/mycity/intents/snow_parking_intent.py
+++ b/mycity/mycity/intents/snow_parking_intent.py
@@ -18,22 +18,23 @@ PARKING_LOCATION_KEY = "Parking Address"
 BOSTON_DATA_PARKING_ADDRESS_INDEX = 9
 
 
-def get_snow_emergency_parking_intent(mcd):
+def get_snow_emergency_parking_intent(mycity_request, mycity_response):
     """
     Populate MyCityDataModel with snow emergency parking response information.
 
-    :param mcd:
-    :return:
+    :param mycity_request: MyCityRequestModel object
+    :param mycity_response: MyCityResponseModel object
+    :return: MyCityResponseModel object
     """
     print(
         '[method: get_snow_emergency_parking_intent]',
         'MyCityDataModel received:',
-        str(mcd)
+        str(mycity_request)
     )
 
-    if intent_constants.CURRENT_ADDRESS_KEY in mcd.session_attributes:
+    if intent_constants.CURRENT_ADDRESS_KEY in mycity_request.session_attributes:
 
-        origin_address = _build_origin_address(mcd)
+        origin_address = _build_origin_address(mycity_request)
 
         print("Finding snow emergency parking for {}".format(origin_address))
 
@@ -41,41 +42,44 @@ def get_snow_emergency_parking_intent(mcd):
             _get_snow_emergency_parking_location(origin_address)
 
         if not parking_address:
-            mcd.output_speech = "Uh oh. Something went wrong!"
+            mycity_response.output_speech = "Uh oh. Something went wrong!"
         else:
-            mcd.output_speech = \
+            mycity_response.output_speech = \
                 "The closest snow emergency parking location is at " \
                 "{}. It is {} away and should take you {} to drive " \
                 "there".format(parking_address, driving_distance, driving_time)
 
-        mcd.should_end_session = False
+        mycity_response.should_end_session = False
     else:
         print("Error: Called snow_parking_intent with no address")
 
     # Setting reprompt_text to None signifies that we do not want to reprompt
     # the user. If the user does not respond or says something that is not
     # understood, the session will end.
-    mcd.reprompt_text = None
-    return mcd
+    mycity_response.reprompt_text = None
+    mycity_response.session_attributes = mycity_request.session_attributes
+    mycity_response.card_title = mycity_request.intent_name
+    
+    return mycity_response
 
 
-def _build_origin_address(mcd):
+def _build_origin_address(mycity_request):
     """
     Builds an address from an Alexa session. Assumes city is Boston if not
     specified
 
-    :param mcd: MyCityDataModel object
+    :param mycity_request: MyCityDataModel object
     :return: String containing full address
     """
     print(
         '[method: _build_origin_address]',
         'MyCityDataModel received:',
-        str(mcd)
+        str(mycity_request)
     )
     # @todo: Repeated code -- look into using same code here and in trash intent
     address_parser = StreetAddressParser()
     current_address = \
-        mcd.session_attributes[intent_constants.CURRENT_ADDRESS_KEY]
+        mycity_request.session_attributes[intent_constants.CURRENT_ADDRESS_KEY]
     parsed_address = address_parser.parse(current_address)
     origin_address = " ".join([parsed_address["house"],
                                parsed_address["street_full"]])

--- a/mycity/mycity/intents/snow_parking_intent.py
+++ b/mycity/mycity/intents/snow_parking_intent.py
@@ -5,7 +5,7 @@ import csv
 import os
 import requests
 from streetaddress import StreetAddressParser
-
+from mycity.mycity_response_data_model import MyCityResponseDataModel
 
 GOOGLE_MAPS_API_KEY = os.environ['GOOGLE_MAPS_API_KEY']
 
@@ -18,7 +18,7 @@ PARKING_LOCATION_KEY = "Parking Address"
 BOSTON_DATA_PARKING_ADDRESS_INDEX = 9
 
 
-def get_snow_emergency_parking_intent(mycity_request, mycity_response):
+def get_snow_emergency_parking_intent(mycity_request):
     """
     Populate MyCityResponseDataModel with snow emergency parking response information.
 
@@ -32,6 +32,7 @@ def get_snow_emergency_parking_intent(mycity_request, mycity_response):
         str(mycity_request)
     )
 
+    mycity_response = MyCityResponseDataModel()
     if intent_constants.CURRENT_ADDRESS_KEY in mycity_request.session_attributes:
 
         origin_address = _build_origin_address(mycity_request)

--- a/mycity/mycity/intents/trash_intent.py
+++ b/mycity/mycity/intents/trash_intent.py
@@ -20,7 +20,7 @@ def get_trash_day_info(mycity_request, mycity_response):
     print(
         '[module: trash_intent]',
         '[method: get_trash_day_info]',
-        'MyCityDataModel received:',
+        'MyCityRequestDataModel received:',
         str(mycity_response)
     )
 

--- a/mycity/mycity/intents/trash_intent.py
+++ b/mycity/mycity/intents/trash_intent.py
@@ -4,26 +4,27 @@ Functions for Alexa responses related to trash day
 
 from .custom_errors import InvalidAddressError, BadAPIResponse
 from streetaddress import StreetAddressParser
+from mycity.mycity_response_data_model import MyCityResponseDataModel
 import requests
 from . import intent_constants
 
 
-def get_trash_day_info(mycity_request, mycity_response):
+def get_trash_day_info(mycity_request):
     """
     Generates response object for a trash day inquiry.
 
-    :param mycity_request: MyCityRequestModel object
-    :param mycity_response: MyCityResponseModel object
-    :return: MyCityResponseModel object
+    :param mycity_request: MyCityRequestDataModel object
+    :return: MyCityResponseDataModel object
     """
     
     print(
         '[module: trash_intent]',
         '[method: get_trash_day_info]',
         'MyCityRequestDataModel received:',
-        str(mycity_response)
+        str(mycity_request)
     )
 
+    mycity_response = MyCityResponseDataModel()
     if intent_constants.CURRENT_ADDRESS_KEY in mycity_request.session_attributes:
         current_address = \
             mycity_request.session_attributes[intent_constants.CURRENT_ADDRESS_KEY]

--- a/mycity/mycity/intents/unhandled_intent.py
+++ b/mycity/mycity/intents/unhandled_intent.py
@@ -10,7 +10,7 @@ def unhandled_intent(mycity_request, mycity_response):
     print(
         '[module: unhandled_intent]',
         '[method: unhandled_intent]',
-        'MyCityDataModel received:',
+        'MyCityRequestDataModel received:',
         str(mycity_request)
     )
     mycity_response.session_attributes = mycity_request.session_attributes

--- a/mycity/mycity/intents/unhandled_intent.py
+++ b/mycity/mycity/intents/unhandled_intent.py
@@ -3,7 +3,7 @@ Function(s) for dealing with unhandled intents
 """
 
 
-def unhandled_intent(mcd):
+def unhandled_intent(mycity_request, mycity_response):
     """
     Deals with unhandled intents by prompting the user again
     """
@@ -11,11 +11,13 @@ def unhandled_intent(mcd):
         '[module: unhandled_intent]',
         '[method: unhandled_intent]',
         'MyCityDataModel received:',
-        str(mcd)
+        str(mycity_request)
     )
-    mcd.reprompt_text = "So, what can I help you with today?"
-    mcd.output_speech = "I'm not sure what you're asking me. " \
+    mycity_response.session_attributes = mycity_request.session_attributes
+    mycity_response.card_title = "Unhandled intent"
+    mycity_response.reprompt_text = "So, what can I help you with today?"
+    mycity_response.output_speech = "I'm not sure what you're asking me. " \
                         "Please ask again."
-    mcd.should_end_session = False
+    mycity_response.should_end_session = False
 
-    return mcd
+    return mycity_response

--- a/mycity/mycity/intents/unhandled_intent.py
+++ b/mycity/mycity/intents/unhandled_intent.py
@@ -1,9 +1,9 @@
 """
 Function(s) for dealing with unhandled intents
 """
+from mycity.mycity_response_data_model import MyCityResponseDataModel
 
-
-def unhandled_intent(mycity_request, mycity_response):
+def unhandled_intent(mycity_request):
     """
     Deals with unhandled intents by prompting the user again
     """
@@ -13,6 +13,7 @@ def unhandled_intent(mycity_request, mycity_response):
         'MyCityRequestDataModel received:',
         str(mycity_request)
     )
+    mycity_response = MyCityResponseDataModel()
     mycity_response.session_attributes = mycity_request.session_attributes
     mycity_response.card_title = "Unhandled intent"
     mycity_response.reprompt_text = "So, what can I help you with today?"

--- a/mycity/mycity/intents/user_address_intent.py
+++ b/mycity/mycity/intents/user_address_intent.py
@@ -5,78 +5,86 @@ Functions for setting and getting the current user address
 from . import intent_constants
 
 
-def set_address_in_session(mcd):
+def set_address_in_session(mycity_request):
     """
     Adds an address to the provided session object
 
-    :param mcd: MyCityRequestModel object
+    :param my_city_request: MyCityRequestModel object
     """
     print(
         '[module: user_address_intent]',
         '[method: set_address_in_session]',
         'MyCityDataModel received:',
-        str(mcd)
+        str(mycity_request)
     )
-    if 'Address' in mcd.intent_variables:
-        mcd.session_attributes[intent_constants.CURRENT_ADDRESS_KEY] = \
-            mcd.intent_variables['Address']['value']
+    if 'Address' in mycity_request.intent_variables:
+        mycity_request.session_attributes[intent_constants.CURRENT_ADDRESS_KEY] = \
+            mycity_request.intent_variables['Address']['value']
 
 
-def get_address_from_session(mcd):
+def get_address_from_session(mycity_request, mycity_response):
     """
     Looks for a current address in the session attributes and constructs a
     response based on whether one exists or not. If one exists, it is
     preserved in the session.
 
-    :param mcd: MyCityDataModel
-    :return:
+    :param mycity_request: MyCityDataModel
+    :param mycity_response: MyCityResponseDataModel
+    :return : MyCityResponseModel object
     """
     print(
         '[module: user_address_intent]',
         '[method: get_address_from_session]',
         'MyCityDataModel received:',
-        str(mcd)
+        str(mycity_request)
     )
 
     # print("GETTING ADDRESS FROM SESSION")
-    mcd.reprompt_text = None
-    mcd.should_end_session = False
+    mycity_response.session_attributes = mycity_request.session_attributes
+    mycity_response.card_title = mycity_request.intent_name
+    mycity_response.reprompt_text = None
+    mycity_response.should_end_session = False
 
-    if intent_constants.CURRENT_ADDRESS_KEY in mcd.session_attributes:
-        current_address = mcd.session_attributes[
+    if intent_constants.CURRENT_ADDRESS_KEY in mycity_request.session_attributes:
+        current_address = mycity_request.session_attributes[
             intent_constants.CURRENT_ADDRESS_KEY]
-        mcd.output_speech = "Your address is " + current_address + "."
+        mycity_response.output_speech = "Your address is " + current_address + "."
     else:
-        mcd.output_speech = "I'm not sure what your address is. " \
-                            "You can tell me your address by saying, " \
-                            "\"my address is\" followed by your address."
+        mycity_response.output_speech = "I'm not sure what your address is. " \
+                                        "You can tell me your address by saying, " \
+                                        "\"my address is\" followed by your address."
 
     # Setting reprompt_text to None signifies that we do not want to reprompt
     # the user. They will be returned to the top level of the skill and must
     # provide input that corresponds to an intent to continue.
 
-    return mcd
+    return mycity_response
 
 
-def request_user_address_response(mcd):
+def request_user_address_response(mycity_request, mycity_response):
     """
     Creates a response to request the user's address
 
-    :param mcd: MyCityRequestModel object
-    :return: MyCityRequestModel object
+    :param mycity_request: MyCityRequestModel object
+    :param mycity_request: MyCityResponseModel object
+    :return: MyCityResponseModel object
     """
     print(
         '[module: user_address_intent]',
         '[method: set_address_in_session]',
         'MyCityDataModel received:',
-        str(mcd)
+        str(mycity_request)
     )
 
-    mcd.session_attributes[intent_constants.ADDRESS_PROMPTED_FROM_INTENT] = \
-        mcd.intent_name
-    mcd.output_speech = "I'm not sure what your address is. " \
-                        "You can tell me your address by saying, " \
-                        "\"my address is\" followed by your address."
-    mcd.should_end_session = False
-    mcd.reprompt_text = None
-    return mcd
+    mycity_request.session_attributes[intent_constants.ADDRESS_PROMPTED_FROM_INTENT] = \
+        mycity_request.intent_name
+    
+    mycity_response.session_attributes = mycity_request.session_attributes
+    mycity_response.card_title = mycity_request.intent_name
+    
+    mycity_response.output_speech = "I'm not sure what your address is. " \
+                                    "You can tell me your address by saying, " \
+                                    "\"my address is\" followed by your address."
+    mycity_response.should_end_session = False
+    mycity_response.reprompt_text = None
+    return mycity_response

--- a/mycity/mycity/intents/user_address_intent.py
+++ b/mycity/mycity/intents/user_address_intent.py
@@ -3,7 +3,7 @@ Functions for setting and getting the current user address
 """
 
 from . import intent_constants
-
+from mycity.mycity_response_data_model import MyCityResponseDataModel
 
 def set_address_in_session(mycity_request):
     """
@@ -22,7 +22,7 @@ def set_address_in_session(mycity_request):
             mycity_request.intent_variables['Address']['value']
 
 
-def get_address_from_session(mycity_request, mycity_response):
+def get_address_from_session(mycity_request):
     """
     Looks for a current address in the session attributes and constructs a
     response based on whether one exists or not. If one exists, it is
@@ -39,6 +39,7 @@ def get_address_from_session(mycity_request, mycity_response):
         str(mycity_request)
     )
 
+    mycity_response = MyCityResponseDataModel()
     # print("GETTING ADDRESS FROM SESSION")
     mycity_response.session_attributes = mycity_request.session_attributes
     mycity_response.card_title = mycity_request.intent_name
@@ -61,7 +62,7 @@ def get_address_from_session(mycity_request, mycity_response):
     return mycity_response
 
 
-def request_user_address_response(mycity_request, mycity_response):
+def request_user_address_response(mycity_request):
     """
     Creates a response to request the user's address
 
@@ -76,6 +77,7 @@ def request_user_address_response(mycity_request, mycity_response):
         str(mycity_request)
     )
 
+    mycity_response = MyCityResponseDataModel()
     mycity_request.session_attributes[intent_constants.ADDRESS_PROMPTED_FROM_INTENT] = \
         mycity_request.intent_name
     

--- a/mycity/mycity/intents/user_address_intent.py
+++ b/mycity/mycity/intents/user_address_intent.py
@@ -14,7 +14,7 @@ def set_address_in_session(mycity_request):
     print(
         '[module: user_address_intent]',
         '[method: set_address_in_session]',
-        'MyCityDataModel received:',
+        'MyCityRequestDataModel received:',
         str(mycity_request)
     )
     if 'Address' in mycity_request.intent_variables:
@@ -28,14 +28,14 @@ def get_address_from_session(mycity_request, mycity_response):
     response based on whether one exists or not. If one exists, it is
     preserved in the session.
 
-    :param mycity_request: MyCityDataModel
+    :param mycity_request: MyCityRequestDataModel
     :param mycity_response: MyCityResponseDataModel
     :return : MyCityResponseModel object
     """
     print(
         '[module: user_address_intent]',
         '[method: get_address_from_session]',
-        'MyCityDataModel received:',
+        'MyCityRequestDataModel received:',
         str(mycity_request)
     )
 
@@ -72,7 +72,7 @@ def request_user_address_response(mycity_request, mycity_response):
     print(
         '[module: user_address_intent]',
         '[method: set_address_in_session]',
-        'MyCityDataModel received:',
+        'MyCityRequestDataModel received:',
         str(mycity_request)
     )
 

--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -26,16 +26,12 @@ class MyCityController:
     """
     LOG_CLASS = '\n\n[class: MyCityController]'
 
-    def __init__(self, mycity_request):
+    def __init__(self):
         """
         Construct the controller.
-
-        @type mycity_request: MyCityRequestDataModel
-        @param mycity_request: Request from platform as a MyCityRequestModel object
         """
-        self._mycity_request = mycity_request
-        self._mycity_response = MyCityResponseDataModel()
-    def execute_request(self):
+        
+    def execute_request(self, mycity_request):
         """
         Route the incoming request based on type (LaunchRequest, IntentRequest,
         etc.) The JSON body of the request is provided in the event parameter.
@@ -44,7 +40,7 @@ class MyCityController:
             self.LOG_CLASS,
             '[method: main]',
             'MyCityRequestDataModel received:\n',
-            str(self._mycity_request)
+            str(mycity_request)
         )
 
         # TODO: This section should be generalized for all platforms if possible
@@ -57,28 +53,28 @@ class MyCityController:
         #         "amzn1.echo-sdk-ams.app.[unique-value-here]"):
         #     raise ValueError("Invalid Application ID")
 
-        if self._mycity_request.is_new_session:
-            self.on_session_started()
+        if mycity_request.is_new_session:
+            self.on_session_started(mycity_request)
 
-        if self._mycity_request.request_type == "LaunchRequest":
-            return self.on_launch()
-        elif self._mycity_request.request_type == "IntentRequest":
-            return self.on_intent()
-        elif self._mycity_request.request_type == "SessionEndedRequest":
-            return self.on_session_ended()
+        if mycity_request.request_type == "LaunchRequest":
+            return self.on_launch(mycity_request)
+        elif mycity_request.request_type == "IntentRequest":
+            return self.on_intent(mycity_request)
+        elif mycity_request.request_type == "SessionEndedRequest":
+            return self.on_session_ended(mycity_request)
 
-    def on_session_started(self):
+    def on_session_started(self, mycity_request):
         """
         Called when the session starts.
         """
         print(
             MyCityController.LOG_CLASS,
             '[method: on_session_started]',
-            '[requestId: ' + str(self._mycity_request.request_id) + ']',
-            '[sessionId: ' + str(self._mycity_request.session_id) + ']'
+            '[requestId: ' + str(mycity_request.request_id) + ']',
+            '[sessionId: ' + str(mycity_request.session_id) + ']'
         )
 
-    def on_launch(self):
+    def on_launch(self, mycity_request):
         """
         Called when the user launches the skill without specifying what
         they want.
@@ -86,20 +82,19 @@ class MyCityController:
         print(
             MyCityController.LOG_CLASS,
             '[method: on_launch]',
-            '[requestId: ' + str(self._mycity_request.request_id) + ']',
-            '[sessionId: ' + str(self._mycity_request.session_id) + ']'
+            '[requestId: ' + str(mycity_request.request_id) + ']',
+            '[sessionId: ' + str(mycity_request.session_id) + ']'
         )
         # Dispatch to your skill's launch
-        return self.get_welcome_response()
+        return self.get_welcome_response(mycity_request)
 
-    def on_intent(self):
+    def on_intent(self, mycity_request):
         """
         If the event type is "request" and the request type is "IntentRequest",
         this function is called to execute the logic associated with the
         provided intent and build a response.
         """
-        mycity_request  = self._mycity_request
-        mycity_response  = self._mycity_response
+
         print(
             self.LOG_CLASS,
             '[method: on_intent]',
@@ -125,34 +120,34 @@ class MyCityController:
                 # from another intent.
                 del mycity_request.session_attributes[intent_constants.ADDRESS_PROMPTED_FROM_INTENT]
             else:
-                return get_address_from_session(mycity_request, mycity_response)
+                return get_address_from_session(mycity_request)
 
         # session_attributes = session.get("attributes", {})
         if mycity_request.intent_name == "GetAddressIntent":
-            return get_address_from_session(mycity_request, mycity_response)
+            return get_address_from_session(mycity_request)
         elif mycity_request.intent_name == "TrashDayIntent":
-            return request_user_address_response(mycity_request, mycity_response) \
+            return request_user_address_response(mycity_request) \
                 if intent_constants.CURRENT_ADDRESS_KEY \
                 not in mycity_request.session_attributes \
-                else get_trash_day_info(mycity_request, mycity_response)
+                else get_trash_day_info(mycity_request)
         elif mycity_request.intent_name == "SnowParkingIntent":
-            return request_user_address_response(mycity_request, mycity_response) \
+            return request_user_address_response(mycity_request) \
                 if intent_constants.CURRENT_ADDRESS_KEY \
                 not in mycity_request.session_attributes \
-                else get_snow_emergency_parking_intent(mycity_request, mycity_response)
+                else get_snow_emergency_parking_intent(mycity_request)
         elif mycity_request.intent_name == "GetAlertsIntent":
-            return get_alerts_intent(mycity_request, mycity_response)
+            return get_alerts_intent(mycity_request)
         elif mycity_request.intent_name == "AMAZON.HelpIntent":
-            return self.get_welcome_response()
+            return self.get_welcome_response(mycity_request)
         elif mycity_request.intent_name == "AMAZON.StopIntent" or \
                 mycity_request.intent_name == "AMAZON.CancelIntent":
-            return self.handle_session_end_request()
+            return self.handle_session_end_request(mycity_request)
         elif mycity_request.intent_name == "UnhandledIntent":
-            return unhandled_intent(mycity_request, mycity_response)
+            return unhandled_intent(mycity_request)
         else:
             raise ValueError("Invalid intent")
 
-    def on_session_ended(self):
+    def on_session_ended(self, mycity_request):
         """
         Called when the user ends the session.
         Is not called when the skill returns should_end_session=true
@@ -161,12 +156,12 @@ class MyCityController:
             self.LOG_CLASS,
             '[method: on_session_ended]',
             'MyCityRequestDataModel received:',
-            str(self._mycity_request)
+            str(mycity_request)
         )
-        return self._mycity_response
+        return MyCityResponseDataModel()
         # add cleanup logic here
 
-    def get_welcome_response(self):
+    def get_welcome_response(self, mycity_request):
         """
         If we wanted to initialize the session to have some attributes we could
         add those here.
@@ -175,25 +170,27 @@ class MyCityController:
             self.LOG_CLASS,
             '[method: get_welcome_response]'
         )
-        self._mycity_response.session_attributes = self._mycity_request.session_attributes
-        self._mycity_response.card_title = "Welcome"
-        self._mycity_response.output_speech = \
+        mycity_response = MyCityResponseDataModel()
+        mycity_response.session_attributes = mycity_request.session_attributes
+        mycity_response.card_title = "Welcome"
+        mycity_response.output_speech = \
             "Welcome to the Boston Public Services skill. How can I help you? "
 
         # If the user either does not reply to the welcome message or says
         # something that is not understood, they will be prompted again with
         # this text.
-        self._mycity_response.reprompt_text = \
+        mycity_response.reprompt_text = \
             "For example, you can tell me your address by saying, " \
             "\"my address is\" followed by your address."
-        self._mycity_response.should_end_session = False
-        return self._mycity_response
+        mycity_response.should_end_session = False
+        return mycity_response
 
-    def handle_session_end_request(self):
-        self._mycity_response.session_attributes = self._mycity_request.session_attributes
-        self._mycity_response.card_title = "Boston Public Services - Thanks"
-        self._mycity_response.output_speech = \
+    def handle_session_end_request(self, mycity_request):
+        mycity_response = MyCityResponseDataModel()
+        mycity_response.session_attributes = mycity_request.session_attributes
+        mycity_response.card_title = "Boston Public Services - Thanks"
+        mycity_response.output_speech = \
             "Thank you for using the Boston Public Services skill. " \
             "See you next time!"
-        self._mycity_response.should_end_session = True
-        return self._mycity_response
+        mycity_response.should_end_session = True
+        return mycity_response

--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -6,6 +6,7 @@ This class handles all voice requests.
 
 from __future__ import print_function
 from mycity.mycity_data_model import MyCityDataModel
+from mycity.mycity_response_data_model import MyCityResponseDataModel
 from .intents.user_address_intent import set_address_in_session, \
     get_address_from_session, request_user_address_response
 from .intents.trash_intent import get_trash_day_info
@@ -25,17 +26,15 @@ class MyCityController:
     """
     LOG_CLASS = '\n\n[class: MyCityController]'
 
-    def __init__(self, mcd):
+    def __init__(self, mycity_request):
         """
         Construct the controller.
 
-        @type mcd: MyCityDataModel
-        @param mcd: Request from platform as a MyCityRequestModel object
+        @type mycity_request: MyCityDataModel
+        @param mycity_request: Request from platform as a MyCityRequestModel object
         """
-        # @TODO: throughout the project we need better naming for mcd
-        self._mcd = mcd
-
-
+        self._mycity_request = mycity_request
+        self._mycity_response = MyCityResponseDataModel()
     def execute_request(self):
         """
         Route the incoming request based on type (LaunchRequest, IntentRequest,
@@ -45,7 +44,7 @@ class MyCityController:
             self.LOG_CLASS,
             '[method: main]',
             'MyCityDataModel received:\n',
-            str(self._mcd)
+            str(self._mycity_request)
         )
 
         # TODO: This section should be generalized for all platforms if possible
@@ -58,14 +57,14 @@ class MyCityController:
         #         "amzn1.echo-sdk-ams.app.[unique-value-here]"):
         #     raise ValueError("Invalid Application ID")
 
-        if self._mcd.is_new_session:
+        if self._mycity_request.is_new_session:
             self.on_session_started()
 
-        if self._mcd.request_type == "LaunchRequest":
+        if self._mycity_request.request_type == "LaunchRequest":
             return self.on_launch()
-        elif self._mcd.request_type == "IntentRequest":
+        elif self._mycity_request.request_type == "IntentRequest":
             return self.on_intent()
-        elif self._mcd.request_type == "SessionEndedRequest":
+        elif self._mycity_request.request_type == "SessionEndedRequest":
             return self.on_session_ended()
 
     def on_session_started(self):
@@ -75,8 +74,8 @@ class MyCityController:
         print(
             MyCityController.LOG_CLASS,
             '[method: on_session_started]',
-            '[requestId: ' + str(self._mcd.request_id) + ']',
-            '[sessionId: ' + str(self._mcd.session_id) + ']'
+            '[requestId: ' + str(self._mycity_request.request_id) + ']',
+            '[sessionId: ' + str(self._mycity_request.session_id) + ']'
         )
 
     def on_launch(self):
@@ -87,8 +86,8 @@ class MyCityController:
         print(
             MyCityController.LOG_CLASS,
             '[method: on_launch]',
-            '[requestId: ' + str(self._mcd.request_id) + ']',
-            '[sessionId: ' + str(self._mcd.session_id) + ']'
+            '[requestId: ' + str(self._mycity_request.request_id) + ']',
+            '[sessionId: ' + str(self._mycity_request.session_id) + ']'
         )
         # Dispatch to your skill's launch
         return self.get_welcome_response()
@@ -99,56 +98,57 @@ class MyCityController:
         this function is called to execute the logic associated with the
         provided intent and build a response.
         """
-        mcd = self._mcd
+        mycity_request  = self._mycity_request
+        mycity_response  = self._mycity_response
         print(
             self.LOG_CLASS,
             '[method: on_intent]',
-            '[intent: ' + mcd.intent_name + ']',
+            '[intent: ' + mycity_request.intent_name + ']',
             'MyCityDataModel received:',
-            mcd
+            mycity_request
         )
 
         # Check if the user is setting the address. This is special cased
         # since they may have been prompted for this info from another intent
-        if mcd.intent_name == "SetAddressIntent":
-            set_address_in_session(mcd)
+        if mycity_request.intent_name == "SetAddressIntent":
+            set_address_in_session(mycity_request)
 
             if intent_constants.ADDRESS_PROMPTED_FROM_INTENT \
-                    in mcd.session_attributes:
+                    in mycity_request.session_attributes:
                 # User was prompted for address from another intent.
                 # Set our current intent to be that original intent now that
                 # we have set the address.
-                mcd.intent_name = mcd.session_attributes[intent_constants.ADDRESS_PROMPTED_FROM_INTENT]
+                mycity_request.intent_name = mycity_request.session_attributes[intent_constants.ADDRESS_PROMPTED_FROM_INTENT]
                 print("Address set after calling another intent. Redirecting "
-                      "intent to {}".format(mcd.intent_name))
+                      "intent to {}".format(mycity_request.intent_name))
                 # Delete the session key indicating this intent was called
                 # from another intent.
-                del mcd.session_attributes[intent_constants.ADDRESS_PROMPTED_FROM_INTENT]
+                del mycity_request.session_attributes[intent_constants.ADDRESS_PROMPTED_FROM_INTENT]
             else:
-                return get_address_from_session(mcd)
+                return get_address_from_session(mycity_request, mycity_response)
 
         # session_attributes = session.get("attributes", {})
-        if mcd.intent_name == "GetAddressIntent":
-            return get_address_from_session(mcd)
-        elif mcd.intent_name == "TrashDayIntent":
-            return request_user_address_response(mcd) \
+        if mycity_request.intent_name == "GetAddressIntent":
+            return get_address_from_session(mycity_request, mycity_response)
+        elif mycity_request.intent_name == "TrashDayIntent":
+            return request_user_address_response(mycity_request, mycity_response) \
                 if intent_constants.CURRENT_ADDRESS_KEY \
-                not in mcd.session_attributes \
-                else get_trash_day_info(mcd)
-        elif mcd.intent_name == "SnowParkingIntent":
-            return request_user_address_response(mcd) \
+                not in mycity_request.session_attributes \
+                else get_trash_day_info(mycity_request, mycity_response)
+        elif mycity_request.intent_name == "SnowParkingIntent":
+            return request_user_address_response(mycity_request, mycity_response) \
                 if intent_constants.CURRENT_ADDRESS_KEY \
-                not in mcd.session_attributes \
-                else get_snow_emergency_parking_intent(mcd)
-        elif mcd.intent_name == "GetAlertsIntent":
-            return get_alerts_intent(mcd)
-        elif mcd.intent_name == "AMAZON.HelpIntent":
+                not in mycity_request.session_attributes \
+                else get_snow_emergency_parking_intent(mycity_request, mycity_response)
+        elif mycity_request.intent_name == "GetAlertsIntent":
+            return get_alerts_intent(mycity_request, mycity_response)
+        elif mycity_request.intent_name == "AMAZON.HelpIntent":
             return self.get_welcome_response()
-        elif mcd.intent_name == "AMAZON.StopIntent" or \
-                mcd.intent_name == "AMAZON.CancelIntent":
+        elif mycity_request.intent_name == "AMAZON.StopIntent" or \
+                mycity_request.intent_name == "AMAZON.CancelIntent":
             return self.handle_session_end_request()
-        elif mcd.intent_name == "UnhandledIntent":
-            return unhandled_intent(mcd)
+        elif mycity_request.intent_name == "UnhandledIntent":
+            return unhandled_intent(mycity_request, mycity_response)
         else:
             raise ValueError("Invalid intent")
 
@@ -161,9 +161,9 @@ class MyCityController:
             self.LOG_CLASS,
             '[method: on_session_ended]',
             'MyCityDataModel received:',
-            str(self._mcd)
+            str(self._mycity_request)
         )
-        return self._mcd
+        return self._mycity_response
         # add cleanup logic here
 
     def get_welcome_response(self):
@@ -175,23 +175,25 @@ class MyCityController:
             self.LOG_CLASS,
             '[method: get_welcome_response]'
         )
-        self._mcd.intent_name = "Welcome"
-        self._mcd.output_speech = \
+        self._mycity_response.session_attributes = self._mycity_request.session_attributes
+        self._mycity_response.card_title = "Welcome"
+        self._mycity_response.output_speech = \
             "Welcome to the Boston Public Services skill. How can I help you? "
 
         # If the user either does not reply to the welcome message or says
         # something that is not understood, they will be prompted again with
         # this text.
-        self._mcd.reprompt_text = \
+        self._mycity_response.reprompt_text = \
             "For example, you can tell me your address by saying, " \
             "\"my address is\" followed by your address."
-        self._mcd.should_end_session = False
-        return self._mcd
+        self._mycity_response.should_end_session = False
+        return self._mycity_response
 
     def handle_session_end_request(self):
-        self._mcd.intent_name = "Boston Public Services - Thanks"
-        self._mcd.output_speech = \
+        self._mycity_response.session_attributes = self._mycity_request.session_attributes
+        self._mycity_response.card_title = "Boston Public Services - Thanks"
+        self._mycity_response.output_speech = \
             "Thank you for using the Boston Public Services skill. " \
             "See you next time!"
-        self._mcd.should_end_session = True
-        return self._mcd
+        self._mycity_response.should_end_session = True
+        return self._mycity_response

--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -5,7 +5,7 @@ This class handles all voice requests.
 """
 
 from __future__ import print_function
-from mycity.mycity_data_model import MyCityDataModel
+from mycity.mycity_request_data_model import MyCityRequestDataModel
 from mycity.mycity_response_data_model import MyCityResponseDataModel
 from .intents.user_address_intent import set_address_in_session, \
     get_address_from_session, request_user_address_response
@@ -21,8 +21,8 @@ class MyCityController:
     Handles requests for the MyCity voice app.
 
 
-    @type mcr: MyCityDataModel
-    @param mcr: Request from platform as a MyCityRequestModel object
+    @type mycity_request: MyCityRequestDataModel
+    @param mycity_request: Request from platform as a MyCityRequestModel object
     """
     LOG_CLASS = '\n\n[class: MyCityController]'
 
@@ -30,7 +30,7 @@ class MyCityController:
         """
         Construct the controller.
 
-        @type mycity_request: MyCityDataModel
+        @type mycity_request: MyCityRequestDataModel
         @param mycity_request: Request from platform as a MyCityRequestModel object
         """
         self._mycity_request = mycity_request
@@ -43,7 +43,7 @@ class MyCityController:
         print(
             self.LOG_CLASS,
             '[method: main]',
-            'MyCityDataModel received:\n',
+            'MyCityRequestDataModel received:\n',
             str(self._mycity_request)
         )
 
@@ -104,7 +104,7 @@ class MyCityController:
             self.LOG_CLASS,
             '[method: on_intent]',
             '[intent: ' + mycity_request.intent_name + ']',
-            'MyCityDataModel received:',
+            'MyCityRequestDataModel received:',
             mycity_request
         )
 
@@ -160,7 +160,7 @@ class MyCityController:
         print(
             self.LOG_CLASS,
             '[method: on_session_ended]',
-            'MyCityDataModel received:',
+            'MyCityRequestDataModel received:',
             str(self._mycity_request)
         )
         return self._mycity_response

--- a/mycity/mycity/mycity_request_data_model.py
+++ b/mycity/mycity/mycity_request_data_model.py
@@ -1,4 +1,4 @@
-class MyCityDataModel:
+class MyCityRequestDataModel:
     """
     Represents a request from a voice platform.
 
@@ -13,14 +13,11 @@ class MyCityDataModel:
         self._session_attributes = {}
         self._application_id = None
         self._intent_name = None
-        self._output_speech = None
-        self._reprompt_text = None
-        self._should_end_session = None
         self._intent_variables = {}
 
     def __str__(self):
         return """\
-        <MyCityDataModel
+        <MyCityRequestDataModel
             request_type={},
             request_id={},
             is_new_session={},
@@ -28,9 +25,6 @@ class MyCityDataModel:
             session_attributes={},
             application_id={},
             intent_name={},
-            output_speech={},
-            reprompt_text={},
-            should_end_session={},
             intent_variables={}
         >
         """.format(
@@ -41,9 +35,6 @@ class MyCityDataModel:
             self._session_attributes,
             self._application_id,
             self._intent_name,
-            self._output_speech,
-            self._reprompt_text,
-            self._should_end_session,
             self._intent_variables
         )
 
@@ -109,39 +100,6 @@ class MyCityDataModel:
     @intent_name.setter
     def intent_name(self, value):
         self._intent_name = value
-
-    @property
-    def output_speech(self):
-        """The script for Alexa's response to the request."""
-        return self._output_speech
-
-    @output_speech.setter
-    def output_speech(self, value):
-        self._output_speech = value
-
-    @property
-    def reprompt_text(self):
-        """
-        The script for Alexa's response in the case that the user needs to
-        be reprompted.
-        """
-        return self._reprompt_text
-
-    @reprompt_text.setter
-    def reprompt_text(self, value):
-        self._reprompt_text = value
-
-    @property
-    def should_end_session(self):
-        """
-        Boolean indicating whether the session should end after this response
-        is received by the platform.
-        """
-        return self._should_end_session
-
-    @should_end_session.setter
-    def should_end_session(self, value):
-        self._should_end_session = value
 
     @property
     def intent_variables(self):

--- a/mycity/mycity/mycity_response_data_model.py
+++ b/mycity/mycity/mycity_response_data_model.py
@@ -1,0 +1,98 @@
+class MyCityResponseDataModel:
+    """
+    Represents a request from a voice platform.
+
+    @todo: Consistent comment format that contains platform-specific terminology
+    """
+
+    def __init__(self):
+        self._session_attributes = {}
+        self._card_title = None
+        self._output_speech = None
+        self._reprompt_text = None
+        self._should_end_session = None
+        self._intent_variables = {}
+
+    def __str__(self):
+        return """\
+        <MyCityResponseDataModel
+            session_attributes={},
+            card_title={},
+            output_speech={},
+            reprompt_text={},
+            should_end_session={},
+            intent_variables={}
+        >
+        """.format(
+            self._session_attributes,
+            self._card_title,
+            self._output_speech,
+            self._reprompt_text,
+            self._should_end_session,
+            self._intent_variables
+        )
+
+    @property
+    def session_attributes(self):
+        """An object containing key-value pairs of session information."""
+        return self._session_attributes
+
+    @session_attributes.setter
+    def session_attributes(self, value):
+        self._session_attributes = value
+
+    @property
+    def card_title(self):
+        """An object containing the title of the card that will be shown."""
+        return self._card_title
+
+    @session_attributes.setter
+    def card_title(self, value):
+        self._card_title = value
+
+    @property
+    def output_speech(self):
+        """The script for Alexa's response to the request."""
+        return self._output_speech
+
+    @output_speech.setter
+    def output_speech(self, value):
+        self._output_speech = value
+
+    @property
+    def reprompt_text(self):
+        """
+        The script for Alexa's response in the case that the user needs to
+        be reprompted.
+        """
+        return self._reprompt_text
+
+    @reprompt_text.setter
+    def reprompt_text(self, value):
+        self._reprompt_text = value
+
+    @property
+    def should_end_session(self):
+        """
+        Boolean indicating whether the session should end after this response
+        is received by the platform.
+        """
+        return self._should_end_session
+
+    @should_end_session.setter
+    def should_end_session(self, value):
+        self._should_end_session = value
+
+    @property
+    def intent_variables(self):
+        """
+        An object containing key-value pairs representing the variables
+        captured in the user's input.
+
+        On the Alexa platform, these are called "slots".
+        """
+        return self._intent_variables
+
+    @intent_variables.setter
+    def intent_variables(self, value):
+        self._intent_variables = value

--- a/mycity/mycity/mycity_response_data_model.py
+++ b/mycity/mycity/mycity_response_data_model.py
@@ -46,7 +46,7 @@ class MyCityResponseDataModel:
         """An object containing the title of the card that will be shown."""
         return self._card_title
 
-    @session_attributes.setter
+    @card_title.setter
     def card_title(self, value):
         self._card_title = value
 

--- a/mycity/platforms/amazon/lambda/custom/lambda_function.py
+++ b/mycity/platforms/amazon/lambda/custom/lambda_function.py
@@ -20,8 +20,8 @@ def lambda_handler(event, context):
     )
 
     model = platform_to_mycity_request(event)
-    controller = MyCityController(model)
-    return mycity_response_to_platform(controller.execute_request())
+    controller = MyCityController()
+    return mycity_response_to_platform(controller.execute_request(model))
 
 
 def platform_to_mycity_request(event):

--- a/mycity/platforms/amazon/lambda/custom/lambda_function.py
+++ b/mycity/platforms/amazon/lambda/custom/lambda_function.py
@@ -19,12 +19,12 @@ def lambda_handler(event, context):
         str(event)
     )
 
-    model = platform_to_mcd(event)
+    model = platform_to_mycity_request(event)
     controller = MyCityController(model)
-    return mcd_to_platform(controller.execute_request())
+    return mycity_response_to_platform(controller.execute_request())
 
 
-def platform_to_mcd(event):
+def platform_to_mycity_request(event):
     """
     Translates from Amazon platform request to MyCityDataModel
 
@@ -33,34 +33,34 @@ def platform_to_mcd(event):
     """
     print(
         "\n\n[module: lambda_function]",
-        "[function: platform_to_mcd]",
+        "[function: platform_to_mycity_request]",
         "Amazon request received:\n",
         str(event)
     )
-    mcd = MyCityDataModel()
-    mcd.request_type = event['request']['type']
-    mcd.request_id = event['request']['requestId']
-    mcd.is_new_session = event['session']['new']
-    mcd.session_id = event['session']['sessionId']
+    mycity_request = MyCityDataModel()
+    mycity_request.request_type = event['request']['type']
+    mycity_request.request_id = event['request']['requestId']
+    mycity_request.is_new_session = event['session']['new']
+    mycity_request.session_id = event['session']['sessionId']
     if 'attributes' in event['session']:
-        mcd.session_attributes = event['session']['attributes']
+        mycity_request.session_attributes = event['session']['attributes']
     else:
-        mcd.session_attributes = {}
-    mcd.application_id = event['session']['application']['applicationId']
+        mycity_request.session_attributes = {}
+    mycity_request.application_id = event['session']['application']['applicationId']
     if 'intent' in event['request']:
-        mcd.intent_name = event['request']['intent']['name']
+        mycity_request.intent_name = event['request']['intent']['name']
         if 'slots' in event['request']['intent']:
-            mcd.intent_variables = event['request']['intent']['slots']
+            mycity_request.intent_variables = event['request']['intent']['slots']
     else:
-        mcd.intent_name = None
-    mcd.output_speech = None
-    mcd.reprompt_text = None
-    mcd.should_end_session = False
+        mycity_request.intent_name = None
+    mycity_request.output_speech = None
+    mycity_request.reprompt_text = None
+    mycity_request.should_end_session = False
 
-    return mcd
+    return mycity_request
 
 
-def mcd_to_platform(mcd):
+def mycity_response_to_platform(mycity_response):
     """
     Translates from MyCityDataModel to Amazon platform response.
 
@@ -70,34 +70,34 @@ def mcd_to_platform(mcd):
     - a response "speechlet" dictionary containing information on how Alexa
       responds to the user command.
 
-    :param mcd:
+    :param mycity_response:
     :return:
     """
     print(
         "\n\n[module: lambda_function]",
-        "[function: mcd_to_platform]",
-        "MyCityDataModel object received: " + str(mcd)
+        "[function: mycity_response_to_platform]",
+        "MyCityDataModel object received: " + str(mycity_response)
     )
     result = {
         'version': '1.0',
-        'sessionAttributes': mcd.session_attributes,
+        'sessionAttributes': mycity_response.session_attributes,
         'response': {
             'outputSpeech': {
                 'type': 'PlainText',
-                'text': mcd.output_speech
+                'text': mycity_response.output_speech
             },
             'card': {
                 'type': 'Simple',
-                'title': 'SessionSpeechlet - ' + str(mcd.intent_name),
-                'content': 'SessionSpeechlet - ' + str(mcd.output_speech)
+                'title': 'SessionSpeechlet - ' + str(mycity_response.card_title),
+                'content': 'SessionSpeechlet - ' + str(mycity_response.output_speech)
             },
             'reprompt': {
                 'outputSpeech': {
                     'type': 'PlainText',
-                    'text': mcd.reprompt_text
+                    'text': mycity_response.reprompt_text
                 }
             },
-            'shouldEndSession': mcd.should_end_session
+            'shouldEndSession': mycity_response.should_end_session
         }
     }
     print('Result to platform:\n', result)

--- a/mycity/platforms/amazon/lambda/custom/lambda_function.py
+++ b/mycity/platforms/amazon/lambda/custom/lambda_function.py
@@ -4,7 +4,7 @@ Boston Data Alexa skill.
 This module is the entry point for processing voice data from an Alexa device.
 """
 
-from mycity.mycity_data_model import MyCityDataModel
+from mycity.mycity_request_data_model import MyCityRequestDataModel
 from mycity.mycity_controller import MyCityController
 
 
@@ -26,7 +26,7 @@ def lambda_handler(event, context):
 
 def platform_to_mycity_request(event):
     """
-    Translates from Amazon platform request to MyCityDataModel
+    Translates from Amazon platform request to MyCityRequestDataModel
 
     :param event:
     :return:
@@ -37,7 +37,7 @@ def platform_to_mycity_request(event):
         "Amazon request received:\n",
         str(event)
     )
-    mycity_request = MyCityDataModel()
+    mycity_request = MyCityRequestDataModel()
     mycity_request.request_type = event['request']['type']
     mycity_request.request_id = event['request']['requestId']
     mycity_request.is_new_session = event['session']['new']
@@ -62,7 +62,7 @@ def platform_to_mycity_request(event):
 
 def mycity_response_to_platform(mycity_response):
     """
-    Translates from MyCityDataModel to Amazon platform response.
+    Translates from MyCityResponseDataModel to Amazon platform response.
 
     The platform response contains:
     - a version number,
@@ -76,7 +76,7 @@ def mycity_response_to_platform(mycity_response):
     print(
         "\n\n[module: lambda_function]",
         "[function: mycity_response_to_platform]",
-        "MyCityDataModel object received: " + str(mycity_response)
+        "MyCityResponseDataModel object received: " + str(mycity_response)
     )
     result = {
         'version': '1.0',


### PR DESCRIPTION
This change does the following:
- Rename the MyCityDataModel to MyCityRequestDataModel and trim its attributes to correspond to only those that are needed for the request object
- Rename the file mycity_data_model.py to mycity_request_data_model.py (to reflect what it now contains)
- Add a new MyCityResponseDataModel class (and a new file mycity_response_data_model.py) to handle the outgoing response (which is then packaged into a  JSON object in lambda_function.py)
- Add a new attribute _mycity_response to the Controller Object to populate the response and return to the lambda_function.
- Change occurrences of mcd into mycity_request or mycity_response within all the intent files,  mycity_controller.py and lambda_function.py
- Change the comments to reflect the above changes

Testing:
- I tested that the Skill works as it did before (by going through the workflow with deploy_tools).
- Verified the trash intent and snow emergency intent work as intended.  The alerts intent did not do anything and just returned by ending the session. I see from the code that this is expected.
- As far as I can tell, the only thing that is not working as expected is when one tries to end the session by saying 'stop'. It is showing up as an unhandled_intent (and not as Amazon.StopIntent). Need to investigate more why.

