### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,23 @@ containing directory instead of its contents, this code is not available.
 
 ## Notes on open data sources for Boston
 
+### https://recollect.net
+
+This is the new (third party) source for Boston's trash day address information.  
+Boston's trash day schedule here: https://www.boston.gov/trash-day-schedule
+labelled 'Powered by ReCollect'.
+
+trash_intent.py accesses the information at recollect.net
+
+jmartini noted on 02/13/2018 in issue #39: "The Boston digital team stated that the trash day info at data.boston.gov is often out of date. They are currently using a 3rd party called ReCollect to manage the newest trash day info."
+
 ### https://data.boston.gov
+
+**DEPRECATED** 
+
+ReCollect is now used as the (third party) source for trash day schedules.
+No intent currently accesses data.boston.gov.
+
 This is the new portal for Boston's open data efforts. This site uses a tool
 called CKAN, which describes itself as follows:
    >CKAN is a tool for making open data websites. (Think of a content management


### PR DESCRIPTION
Update README.md to reflect trash_intent.py uses recollect.net (no longer data.boston.gov) as source for trash day info.