### PR TITLE
Intent cleaned responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,6 @@ jmartini noted on 02/13/2018 in issue #39: "The Boston digital team stated that 
 
 ### https://data.boston.gov
 
-**DEPRECATED** 
-
 ReCollect is now used as the (third party) source for trash day schedules.
 No intent currently accesses data.boston.gov.
 

--- a/mycity/mycity/intents/get_alerts_intent.py
+++ b/mycity/mycity/intents/get_alerts_intent.py
@@ -82,7 +82,7 @@ def alerts_to_speech_output(alerts):
     for alert in alerts.values():
         all_alerts += alert + ' '
     if all_alerts.strip() == "":        # this is a kludgy fix for the {'alert header': ''} bug 
-        return "There are no alerts. City services are operating on their normal schedule."       
+        return "I see no alerts. City services are running on their normal schedules."       
     else:
         return all_alerts
         

--- a/mycity/mycity/intents/get_alerts_intent.py
+++ b/mycity/mycity/intents/get_alerts_intent.py
@@ -82,7 +82,7 @@ def alerts_to_speech_output(alerts):
     for alert in alerts.values():
         all_alerts += alert + ' '
     if all_alerts.strip() == "":        # this is a kludgy fix for the {'alert header': ''} bug 
-        return "I see no alerts. City services are running on their normal schedules."       
+        return "There are no alerts. City services are running on normal schedules."       
     else:
         return all_alerts
         

--- a/mycity/mycity/intents/snow_parking_intent.py
+++ b/mycity/mycity/intents/snow_parking_intent.py
@@ -16,9 +16,9 @@ PARKING_INFO_URL = ("http://bostonopendata-boston.opendata.arcgis.com/datasets/"
 DRIVING_DIST = g_maps_utils.DRIVING_DISTANCE_TEXT_KEY
 DRIVING_TIME = g_maps_utils.DRIVING_TIME_TEXT_KEY
 OUTPUT_SPEECH_FORMAT = \
-    ("The closest snow emergency parking location, {Name}, is at "
+    ("The closest snow emergency parking lot, {Name}, is at "
      "{Address}. It is {" + DRIVING_DIST + "} away and should take "
-     "you {" + DRIVING_TIME + "} to drive there. The parking lot has "
+     "you {" + DRIVING_TIME + "} to drive there from home. The lot has "
      "{Spaces} spaces when empty. {Fee} {Comments} {Phone}")
 ADDRESS_KEY = "Address"
 
@@ -26,7 +26,7 @@ ADDRESS_KEY = "Address"
 def format_record_fields(record):
    record["Phone"] = "Call {} for information.".format(record["Phone"]) \
        if record["Phone"].strip() != "" else ""
-   record["Fee"] = " There is a fee of {}. ".format(record["Fee"]) \
+   record["Fee"] = " The fee is {}. ".format(record["Fee"]) \
        if record["Fee"] != "No Charge" else " There is no fee. "
    
 
@@ -53,6 +53,7 @@ def get_snow_emergency_parking_intent(mycity_request):
 
     else:
         print("Error: Called snow_parking_intent with no address")
+        mycity_response.output_speech = "I need a valid address to find the closest parking"
 
     # Setting reprompt_text to None signifies that we do not want to reprompt
     # the user. If the user does not respond or says something that is not

--- a/mycity/mycity/intents/snow_parking_intent.py
+++ b/mycity/mycity/intents/snow_parking_intent.py
@@ -18,7 +18,7 @@ DRIVING_TIME = g_maps_utils.DRIVING_TIME_TEXT_KEY
 OUTPUT_SPEECH_FORMAT = \
     ("The closest snow emergency parking lot, {Name}, is at "
      "{Address}. It is {" + DRIVING_DIST + "} away and should take "
-     "you {" + DRIVING_TIME + "} to drive there from home. The lot has "
+     "you {" + DRIVING_TIME + "} to drive there. The lot has "
      "{Spaces} spaces when empty. {Fee} {Comments} {Phone}")
 ADDRESS_KEY = "Address"
 

--- a/mycity/mycity/intents/trash_intent.py
+++ b/mycity/mycity/intents/trash_intent.py
@@ -46,11 +46,12 @@ def get_trash_day_info(mycity_request):
             mycity_response.output_speech = "I can't seem to find {}. Try another address"\
                .format(address)
         except BadAPIResponse:
-            mycity_response.output_speech = "Hmm something went wrong. Maybe try again?"
+            mycity_response.output_speech = "Hmm something went wrong. Please try again"
 
         mycity_response.should_end_session = False
     else:
         print("Error: Called trash_day_intent with no address")
+        mycity_response.output_speech = "I didn't understand that address, please try again"
 
     # Setting reprompt_text to None signifies that we do not want to reprompt
     # the user. If the user does not respond or says something that is not

--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -193,14 +193,14 @@ def get_welcome_response(mycity_request):
     mycity_response.session_attributes = mycity_request.session_attributes
     mycity_response.card_title = "Welcome"
     mycity_response.output_speech = \
-        "Welcome to the Boston Public Services skill. How can I help you? "
+        "Welcome to the Boston Public Services skill. How may I help you? "
 
     # If the user either does not reply to the welcome message or says
     # something that is not understood, they will be prompted again with
     # this text.
     mycity_response.reprompt_text = \
-        "For example, you can tell me your address by saying, " \
-        "\"my address is\" followed by your address."
+        "You can tell me your address by saying, " \
+        "\"my address is\", and then your address."
     mycity_response.should_end_session = False
     return mycity_response
 


### PR DESCRIPTION
Addressing Issue #108, Alexa script audit and clean up.
Modified these files to reduce syllables and retain clarity.

mycity/mycity/intents/get_alerts_intent.py
mycity/mycity/intents/snow_parking_intent.py
mycity/mycity/intents/trash_intent.py
mycity/mycity/mycity_controller.py

Some snow emergency parking responses are still wordy, because the comments are pulled from the Comments column of http://bostonopendata-boston.opendata.arcgis.com/datasets/53ebc23fcc654111b642f70e61c63852_0.csv. How to deal with the wordy Comments column is not a matter for this bug but is still an issue.