### PR TITLE
Bugfix/100 multiple addresses

### DIFF
--- a/mycity/mycity/intents/custom_errors.py
+++ b/mycity/mycity/intents/custom_errors.py
@@ -9,3 +9,8 @@ class InvalidAddressError(Exception):
 class BadAPIResponse(Exception):
     """Error for bad responses from external APIs"""
     pass
+
+
+class MultipleAddressError(Exception):
+    """Error for finding multiple addresses with the current info"""
+    pass

--- a/mycity/mycity/intents/intent_constants.py
+++ b/mycity/mycity/intents/intent_constants.py
@@ -2,3 +2,4 @@
 
 # The key used for the current address in session attributes
 CURRENT_ADDRESS_KEY = "currentAddress"
+ZIP_CODE_KEY = "Zipcode"

--- a/mycity/mycity/intents/trash_intent.py
+++ b/mycity/mycity/intents/trash_intent.py
@@ -236,8 +236,3 @@ def build_speech_from_list_of_days(days):
         output_speech += ", and {}".format(days[-1])
 
     return output_speech
-
-from mycity.mycity_request_data_model import MyCityRequestDataModel
-mcr = MyCityRequestDataModel()
-mcr.session_attributes = {intent_constants.CURRENT_ADDRESS_KEY: "50 Washington Street"}
-print(get_trash_day_info(mcr))

--- a/mycity/mycity/intents/trash_intent.py
+++ b/mycity/mycity/intents/trash_intent.py
@@ -5,6 +5,7 @@ from .custom_errors import \
     InvalidAddressError, BadAPIResponse, MultipleAddressError
 from streetaddress import StreetAddressParser
 from mycity.mycity_response_data_model import MyCityResponseDataModel
+from mycity.intents.user_address_intent import clear_address_from_mycity_object
 import re
 import requests
 from . import intent_constants
@@ -58,6 +59,9 @@ def get_trash_day_info(mycity_request):
             mycity_response.output_speech =\
                 "I can't seem to find {}. Try another address"\
                 .format(address_string)
+            mycity_request = clear_address_from_mycity_object(mycity_request)
+            mycity_response = clear_address_from_mycity_object(mycity_response)
+
         except BadAPIResponse:
             mycity_response.output_speech =\
                 "Hmm something went wrong. Maybe try again?"

--- a/mycity/mycity/intents/trash_intent.py
+++ b/mycity/mycity/intents/trash_intent.py
@@ -1,7 +1,8 @@
 """
 Functions for Alexa responses related to trash day
 """
-from .custom_errors import InvalidAddressError, BadAPIResponse
+from .custom_errors import \
+    InvalidAddressError, BadAPIResponse, MultipleAddressError
 from streetaddress import StreetAddressParser
 from mycity.mycity_response_data_model import MyCityResponseDataModel
 import re

--- a/mycity/mycity/intents/trash_intent.py
+++ b/mycity/mycity/intents/trash_intent.py
@@ -49,10 +49,12 @@ def get_trash_day_info(mycity_request):
             if zip_code:
                 address_string = address_string + " with zip code {}"\
                     .format(zip_code)
-            mycity_response.output_speech = "I can't seem to find {}. Try another address"\
-               .format(address_string)
+            mycity_response.output_speech =\
+                "I can't seem to find {}. Try another address"\
+                .format(address_string)
         except BadAPIResponse:
-            mycity_response.output_speech = "Hmm something went wrong. Maybe try again?"
+            mycity_response.output_speech =\
+                "Hmm something went wrong. Maybe try again?"
         except MultipleAddressError:
             mycity_response.output_speech \
                 = "I found multiple places with the address {}. Try "\
@@ -77,6 +79,7 @@ def get_trash_and_recycling_days(address, zip_code=None):
     These are on the same day, so only one array of days will be returned.
 
     :param address: String of address to find trash day for
+    :param zip_code: Optional zip code to resolve multiple addresses
     :return: array containing next trash and recycling days
     """
 
@@ -120,7 +123,8 @@ def get_address_api_info(address, provided_zip_code=None):
     Gets the parameters required for the ReCollect API call
 
     :param address: Address to get parameters for
-    :param zip_code: Optional zip code used if we find multiple addresses
+    :param provided_zip_code: Optional zip code used if we find multiple
+        addresses
     :return: JSON object containing API parameters with format:
 
     {

--- a/mycity/mycity/intents/user_address_intent.py
+++ b/mycity/mycity/intents/user_address_intent.py
@@ -23,6 +23,17 @@ def set_address_in_session(mycity_request):
             mycity_request.intent_variables['Address']['value']
 
 
+def set_zipcode_in_session(mycity_request):
+    """
+    Adds a zip code to the provided request object.
+
+    :param mycity_request: MyCityRequestsDataModel object
+    :return: none
+    """
+    if 'Zipcode' in mycity_request.intent_variables:
+        mycity_request.session_attributes[intent_constants.ZIP_CODE_KEY] = \
+            mycity_request.intent_variables['Zipcode']['value'].zfill(5)
+
 def get_address_from_session(mycity_request):
     """
     Looks for a current address in the session attributes and constructs a

--- a/mycity/mycity/intents/user_address_intent.py
+++ b/mycity/mycity/intents/user_address_intent.py
@@ -24,6 +24,12 @@ def set_address_in_session(mycity_request):
         mycity_request.session_attributes[intent_constants.CURRENT_ADDRESS_KEY] = \
             mycity_request.intent_variables['Address']['value']
 
+        if intent_constants.ZIP_CODE_KEY in mycity_request.session_attributes:
+            # We clear out any zip code saved if the user has
+            # changed the address
+            del(mycity_request.session_attributes
+                [intent_constants.ZIP_CODE_KEY])
+
 
 def set_zipcode_in_session(mycity_request):
     """

--- a/mycity/mycity/intents/user_address_intent.py
+++ b/mycity/mycity/intents/user_address_intent.py
@@ -94,3 +94,21 @@ def request_user_address_response(mycity_request):
 
     mycity_response.dialog_directive = "Delegate"
     return mycity_response
+
+
+def clear_address_from_mycity_object(mycity_object):
+    """
+    Removes any address info from a mycity object session attribute
+
+    :param mycity_object: Either a MyCityResponseDataModel or
+        MyCityRequestDataModel
+    :return: MyCity object with attributes removed
+    """
+    if intent_constants.ZIP_CODE_KEY in mycity_object.session_attributes:
+        del(mycity_object.session_attributes[intent_constants.ZIP_CODE_KEY])
+
+    if intent_constants.CURRENT_ADDRESS_KEY in mycity_object.session_attributes:
+        del(mycity_object.session_attributes[
+            intent_constants.CURRENT_ADDRESS_KEY])
+
+    return mycity_object

--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -8,7 +8,8 @@ from __future__ import print_function
 from mycity.mycity_request_data_model import MyCityRequestDataModel
 from mycity.mycity_response_data_model import MyCityResponseDataModel
 from .intents.user_address_intent import set_address_in_session, \
-    get_address_from_session, request_user_address_response
+    get_address_from_session, request_user_address_response, \
+    set_zipcode_in_session
 from .intents.trash_intent import get_trash_day_info
 from .intents.unhandled_intent import unhandled_intent
 from .intents.get_alerts_intent import get_alerts_intent
@@ -126,6 +127,10 @@ def on_intent(mycity_request):
         # Some of our intents have an associated address value.
         # Capture that into session data here
         set_address_in_session(mycity_request)
+
+    if "Zipcode" in mycity_request.intent_variables \
+        and "value" in mycity_request.intent_variables["Zipcode"]:
+        set_zipcode_in_session(mycity_request)
 
     # session_attributes = session.get("attributes", {})
     if mycity_request.intent_name == "GetAddressIntent":

--- a/mycity/mycity/mycity_response_data_model.py
+++ b/mycity/mycity/mycity_response_data_model.py
@@ -13,6 +13,7 @@ class MyCityResponseDataModel:
         self._should_end_session = None
         self._intent_variables = {}
         self._dialog_directive = None
+        self._slot_to_elicit = None
 
     def __str__(self):
         return """\
@@ -24,6 +25,7 @@ class MyCityResponseDataModel:
             should_end_session={},
             intent_variables={}
             dialog_directive={}
+            slot_to_elicit={}
         >
         """.format(
             self._session_attributes,
@@ -32,7 +34,8 @@ class MyCityResponseDataModel:
             self._reprompt_text,
             self._should_end_session,
             self._intent_variables,
-            self._dialog_directive
+            self._dialog_directive,
+            self._slot_to_elicit
         )
 
     @property
@@ -100,7 +103,6 @@ class MyCityResponseDataModel:
     def intent_variables(self, value):
         self._intent_variables = value
 
-
     @property
     def dialog_directive(self):
         return self._dialog_directive
@@ -108,10 +110,28 @@ class MyCityResponseDataModel:
     @dialog_directive.setter
     def dialog_directive(self, value):
         valid_directives = [
-            "Delegate"          # Delegate dialog decision to platform
+            "Delegate",          # Delegate dialog decision to platform
+            "ElicitSlot"
         ]
 
         if value not in valid_directives:
             print("Error: {} is not a valid directive".format(value))
             return
         self._dialog_directive = "Dialog.{}".format(value)
+
+    @property
+    def slot_to_elicit(self):
+        return self._slot_to_elicit
+
+    @slot_to_elicit.setter
+    def slot_to_elicit(self, value):
+        self._slot_to_elicit = value
+
+    def elicit_slot(self, slot_name):
+        """
+        Helper function for eliciting a particular slot
+
+        :param slot_name: Name of slot to elicits
+        """
+        self._dialog_directive = "Dialog.ElicitSlot"
+        self._slot_to_elicit = slot_name

--- a/mycity/mycity/test/integration_tests/intent_test_mixins.py
+++ b/mycity/mycity/test/integration_tests/intent_test_mixins.py
@@ -17,7 +17,7 @@ class CardTitleTestMixIn:
 
     def test_returns_correct_title_card(self):
         response = self.controller.on_intent(self.request)
-        self.assertEqual(response.card_title, self.intent_to_test)
+        self.assertEqual(response.card_title, self.expected_card_title)
 
 
 # there are some intents where it makes sense to write custom tests for error

--- a/mycity/mycity/test/integration_tests/test_get_alerts.py
+++ b/mycity/mycity/test/integration_tests/test_get_alerts.py
@@ -13,6 +13,7 @@ class GetAlertsTestCase(mix_ins.RepromptTextTestMixIn,
                         base_case.IntentBaseCase):
 
     intent_to_test = "GetAlertsIntent"
+    expected_card_title = "City Alerts"
     returns_reprompt_text = False
     # if we don't create copies of these dictionaries we'll create empty
     # dictionary errors after successive setUps and tearDowns
@@ -42,7 +43,7 @@ class GetAlertsTestCase(mix_ins.RepromptTextTestMixIn,
     def test_response_with_no_alerts(self, mock_get_alerts):
         response = self.controller.on_intent(self.request)
         expected_response = ("There are no alerts. City services are "
-                             "operating on their normal schedule.")
+                             "running on normal schedules.")
         self.assertEqual(response.output_speech, expected_response)
         
     @mock.patch('mycity.intents.get_alerts_intent.get_alerts',

--- a/mycity/mycity/test/integration_tests/test_snow_emergency_parking.py
+++ b/mycity/mycity/test/integration_tests/test_snow_emergency_parking.py
@@ -16,6 +16,7 @@ class SnowEmergencyTestCase(mix_ins.RepromptTextTestMixIn,
 
     intent_to_test = "SnowParkingIntent"
     returns_reprompt_text = False
+    expected_card_title = "Snow Parking"
 
     def setUp(self):
         """

--- a/mycity/mycity/test/integration_tests/test_trash_intent.py
+++ b/mycity/mycity/test/integration_tests/test_trash_intent.py
@@ -15,6 +15,7 @@ class TrashDayTestCase(mix_ins.RepromptTextTestMixIn,
 
     intent_to_test = "TrashDayIntent"
     returns_reprompt_text = False
+    expected_card_title = "Trash Day"
 
     def setUp(self):
         """

--- a/mycity/mycity/test/integration_tests/test_unhandled_intent.py
+++ b/mycity/mycity/test/integration_tests/test_unhandled_intent.py
@@ -14,3 +14,4 @@ class UnhandledIntentTestCase(mix_ins.RepromptTextTestMixIn,
 
     intent_to_test = "UnhandledIntent"
     returns_reprompt_text = True
+    expected_card_title = "Unhandled"

--- a/mycity/mycity/test/unit_tests/test_mycity_controller.py
+++ b/mycity/mycity/test/unit_tests/test_mycity_controller.py
@@ -31,8 +31,8 @@ class MyCityControllerUnitTestCase(base.BaseTestCase):
             "How can I help you? "
         )
         expected_reprompt_text = (
-            "For example, you can tell me your address by saying, "
-            "\"my address is\" followed by your address."
+            "You can tell me your address by saying, "
+            "\"my address is\", and then your address."
         )
         expected_card_title = "Welcome"
         response = self.controller.on_launch(self.request)

--- a/mycity/platforms/amazon/lambda/custom/lambda_function.py
+++ b/mycity/platforms/amazon/lambda/custom/lambda_function.py
@@ -87,7 +87,7 @@ def mycity_response_to_platform(mycity_response):
         "MyCityResponseDataModel object received: " + str(mycity_response)
     )
 
-    if mycity_response.dialog_directive:
+    if mycity_response.dialog_directive == "Dialog.Delegate":
         response = {
             'directives': [
                 {'type': mycity_response.dialog_directive}
@@ -112,6 +112,16 @@ def mycity_response_to_platform(mycity_response):
             },
             'shouldEndSession': mycity_response.should_end_session
         }
+
+    if mycity_response.dialog_directive == "Dialog.ElicitSlot":
+        #Add the slot we want to elicit on top of the normal output.
+        print("Setting elicit slot options")
+        response["directives"] = [
+            {
+                "type": mycity_response.dialog_directive,
+                "slotToElicit": mycity_response.slot_to_elicit
+            }]
+
 
     result = {
         'version': '1.0',

--- a/mycity/platforms/amazon/models/en_US.json
+++ b/mycity/platforms/amazon/models/en_US.json
@@ -33,6 +33,10 @@
                                 "My address is {Address}",
                                 "{Address}"
                             ]
+                        },
+                        {
+                            "name": "Zipcode",
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
@@ -127,6 +131,13 @@
                             "prompts": {
                                 "elicitation": "Elicit.Slot.604703910902.353139060048"
                             }
+                        },
+                        {
+                            "name": "Zipcode",
+                            "type": "AMAZON.NUMBER",
+                            "confirmationRequired": false,
+                            "elicitationRequired": false,
+                            "prompts": {}
                         }
                     ]
                 },


### PR DESCRIPTION
Resolves #100 

When activating the trash day intent, the ReCollect API can return multiple addresses with different zip codes. We will now request from the user their zipcode to resolve which address they want.

This introduces the `slot_to_elicit` property in the My City response object. Setting this to a valid slot name and setting `dialog_directive` to `ElicitSlot` will trigger Alexa to invoke that slot interaction, as specified in the interaction model.