### PR TITLE
Intent cards

### DIFF
--- a/mycity/mycity/intents/get_alerts_intent.py
+++ b/mycity/mycity/intents/get_alerts_intent.py
@@ -59,7 +59,7 @@ def get_alerts_intent(mycity_request):
     alerts = prune_normal_responses(alerts)
     print("[dictionary after pruning]:\n" + str(alerts))
     mycity_response.session_attributes = mycity_request.session_attributes
-    mycity_response.card_title = mycity_request.intent_name
+    mycity_response.card_title = "City Alerts"
     mycity_response.reprompt_text = None
     mycity_response.output_speech = alerts_to_speech_output(alerts)
     mycity_response.should_end_session = True   # leave this as True for right now

--- a/mycity/mycity/intents/snow_parking_intent.py
+++ b/mycity/mycity/intents/snow_parking_intent.py
@@ -59,7 +59,7 @@ def get_snow_emergency_parking_intent(mycity_request):
     # understood, the session will end.
     mycity_response.reprompt_text = None
     mycity_response.session_attributes = mycity_request.session_attributes
-    mycity_response.card_title = mycity_request.intent_name
+    mycity_response.card_title = "Snow Parking"
     
     return mycity_response
 

--- a/mycity/mycity/intents/trash_intent.py
+++ b/mycity/mycity/intents/trash_intent.py
@@ -57,8 +57,8 @@ def get_trash_day_info(mycity_request):
     # understood, the session will end.
     mycity_response.reprompt_text = None
     mycity_response.session_attributes = mycity_request.session_attributes
-    mycity_response.card_title = mycity_request.intent_name
-    return mycity_response
+    mycity_response.card_title = "Trash Day"
+    return mycity_response 
 
 
 def get_trash_and_recycling_days(address):

--- a/mycity/mycity/intents/unhandled_intent.py
+++ b/mycity/mycity/intents/unhandled_intent.py
@@ -18,7 +18,7 @@ def unhandled_intent(mycity_request):
     )
     mycity_response = MyCityResponseDataModel()
     mycity_response.session_attributes = mycity_request.session_attributes
-    mycity_response.card_title = "UnhandledIntent"
+    mycity_response.card_title = "Unhandled"
     mycity_response.reprompt_text = "So, what can I help you with today?"
     mycity_response.output_speech = "I'm not sure what you're asking me. " \
                         "Please ask again."

--- a/mycity/mycity/intents/user_address_intent.py
+++ b/mycity/mycity/intents/user_address_intent.py
@@ -80,6 +80,7 @@ def request_user_address_response(mycity_request):
 
     mycity_response.session_attributes = mycity_request.session_attributes
     mycity_response.should_end_session = False
-
+    mycity_response.output_speech = "What's your address?"
+    mycity_response.card_title = "Address"
     mycity_response.dialog_directive = "Delegate"
     return mycity_response

--- a/mycity/mycity/intents/user_address_intent.py
+++ b/mycity/mycity/intents/user_address_intent.py
@@ -42,7 +42,7 @@ def get_address_from_session(mycity_request):
     mycity_response = MyCityResponseDataModel()
     # print("GETTING ADDRESS FROM SESSION")
     mycity_response.session_attributes = mycity_request.session_attributes
-    mycity_response.card_title = mycity_request.intent_name
+    mycity_response.card_title = "Address"
     mycity_response.reprompt_text = None
     mycity_response.should_end_session = False
 

--- a/mycity/platforms/amazon/lambda/custom/lambda_function.py
+++ b/mycity/platforms/amazon/lambda/custom/lambda_function.py
@@ -91,7 +91,12 @@ def mycity_response_to_platform(mycity_response):
         response = {
             'directives': [
                 {'type': mycity_response.dialog_directive}
-            ]
+            ],
+            'card': {
+                'type': 'Simple',
+                'title': str(mycity_response.card_title),
+                'content': str(mycity_response.output_speech)
+             }
         }
     else:
         response = {

--- a/mycity/platforms/amazon/lambda/custom/lambda_function.py
+++ b/mycity/platforms/amazon/lambda/custom/lambda_function.py
@@ -101,8 +101,8 @@ def mycity_response_to_platform(mycity_response):
             },
             'card': {
                 'type': 'Simple',
-                'title': 'SessionSpeechlet - ' + str(mycity_response.card_title),
-                'content': 'SessionSpeechlet - ' + str(mycity_response.output_speech)
+                'title': str(mycity_response.card_title),
+                'content': str(mycity_response.output_speech)
             },
             'reprompt': {
                 'outputSpeech': {


### PR DESCRIPTION
issue #109 Cleaned up cards that show on Echo displays.
        modified:   mycity/mycity/intents/get_alerts_intent.py
        modified:   mycity/mycity/intents/snow_parking_intent.py
        modified:   mycity/mycity/intents/trash_intent.py
        modified:   mycity/mycity/intents/unhandled_intent.py
        modified:   mycity/mycity/intents/user_address_intent.py
        modified:   mycity/platforms/amazon/lambda/custom/lambda_function.py

Changed names of intents as they show on the cards to be more user-friendly and informative.
Removed the "Session Speechlet" text that preceded the response to the user on the cards from lambda_function.py.