### PR TITLE
Add user feedback intent 104

### DIFF
--- a/mycity/mycity/intents/feedback_intent.py
+++ b/mycity/mycity/intents/feedback_intent.py
@@ -1,0 +1,96 @@
+"""
+The feedback intent allows the user to provide feedback about the skill,
+including bug reports and suggestions for new intents.
+"""
+
+from mycity.mycity_response_data_model import MyCityResponseDataModel
+import requests
+import json
+import os
+
+SLACK_WEBHOOKS_URL = os.environ['SLACK_WEBHOOKS_URL']
+
+
+def submit_feedback(mycity_request):
+    """
+    Logs user feedback to the mycity-feedback slack channel.
+
+    :param mycity_request: MyCityRequestDataModel object
+    :return: MyCityResponseDataModel object
+    """
+    print(
+        '[module: feedback_intent]',
+        '[method: submit_feedback]',
+        'MyCityRequestDataModel received:',
+        str(mycity_request)
+    )
+    # get the intent_variables object from the request
+    intent_variables = mycity_request.intent_variables
+
+    # Build the response.
+    #   - if we are missing the feedback type or feedback text, we'll delegate
+    #     to the dialog model to request the missing information
+    #   - if we have everything we need, we'll pose the message to slack and
+    #     confirm to the user
+    mycity_response = MyCityResponseDataModel()
+    mycity_response.session_attributes = mycity_request.session_attributes
+    mycity_response.should_end_session = False
+    if (
+            'value' not in intent_variables['FeedbackType'] or
+            'value' not in intent_variables['Feedback']
+    ):
+        mycity_response.intent_variables = intent_variables
+        mycity_response.dialog_directive = "Delegate"
+        return mycity_response
+    else:
+        feedback_type = intent_variables['FeedbackType']['value']
+        feedback_text = intent_variables['Feedback']['value']
+        status = send_to_slack(
+            build_slack_message(feedback_type, feedback_text)
+        )
+        if status == 200:
+            mycity_response.output_speech = 'Thanks for your feedback.'
+        else:
+            mycity_response.output_speech = \
+                'There was a problem with your feedback. Please try again.'
+        mycity_response.reprompt_text = None
+        mycity_response.session_attributes = mycity_request.session_attributes
+        mycity_response.card_title = "Feedback"
+    return mycity_response
+
+
+def send_to_slack(message):
+    """
+    Posts feedback in the mycity-feedback Slack channel via HTTP request.
+
+    :param message:
+    :return:
+    """
+    print(
+        '[module: feedback_intent]',
+        '[method: send_to_slack]',
+        'message received:',
+        message
+    )
+    data = json.dumps({'text': message})
+    headers = {'Content-Type': 'application/json'}
+    request = requests.post(SLACK_WEBHOOKS_URL, data, headers)
+    return request.status_code
+
+
+def build_slack_message(feedback_type, feedback_text):
+    """
+    Configures the message we will post to slack.
+
+    :param feedback_type:
+    :param feedback_text:
+    :return:
+    """
+    print(
+        '[module: feedback_intent]',
+        '[method: build_slack_message]',
+        'feedback type and text received:',
+        feedback_type + ', ' + feedback_text
+    )
+    emoji = ':bug:' if feedback_type == 'bug' else ':bulb:'
+    return emoji + '\n>' + feedback_text

--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -14,6 +14,7 @@ from .intents.trash_intent import get_trash_day_info
 from .intents.unhandled_intent import unhandled_intent
 from .intents.get_alerts_intent import get_alerts_intent
 from .intents.snow_parking_intent import get_snow_emergency_parking_intent
+from .intents.feedback_intent import submit_feedback
 from .intents import intent_constants
 
 
@@ -155,6 +156,8 @@ def on_intent(mycity_request):
     elif mycity_request.intent_name == "AMAZON.StopIntent" or \
             mycity_request.intent_name == "AMAZON.CancelIntent":
         return handle_session_end_request(mycity_request)
+    elif mycity_request.intent_name == "FeedbackIntent":
+        return submit_feedback(mycity_request)
     elif mycity_request.intent_name == "UnhandledIntent":
         return unhandled_intent(mycity_request)
     else:
@@ -183,8 +186,7 @@ def on_session_ended(mycity_request):
 
 def get_help_response(mycity_request):
     """
-    Informs the user of currently functionality. This is triggered on
-    AMAZON.HelpIntent.
+    Provides an overview of the skill. This is triggered by AMAZON.HelpIntent.
 
     :param mycity_request: MyCityRequestDataModel object
     :return: MyCityResponseDataModel object that will initiate
@@ -197,14 +199,13 @@ def get_help_response(mycity_request):
     mycity_response = MyCityResponseDataModel()
     mycity_response.session_attributes = mycity_request.session_attributes
     mycity_response.card_title = "Help"
-    mycity_response.output_speech = \
-        "You can request information on trash and recycling pickup by saying, " \
-        "When is trash pick up at 123 example st. This is currently " \
-        "only available for Boston residents. " \
-        "You can also request the closest location for snow emergency parking by saying, " \
-        "where can I park during a snow emergency? You can also request all Boston city alerts " \
-        "by saying, 'are there any alerts?'."
-
+    mycity_response.output_speech = (
+        "You are using Boston Info, a skill that provides general information "
+        "about Boston. You can currently ask about your trash and recycling "
+        "pickup schedule, the location of the nearest snow emergency parking,"
+        "and current alerts from Boston.gov. If you have feedback for the "
+        "skill, say, 'I have a suggestion.'"
+     )
     mycity_response.reprompt_text = None
     mycity_response.should_end_session = False
     return mycity_response

--- a/mycity/platforms/amazon/models/en_US.json
+++ b/mycity/platforms/amazon/models/en_US.json
@@ -1025,9 +1025,72 @@
                 {
                     "name": "AMAZON.CancelIntent",
                     "samples": []
+                },
+                {
+                    "name": "FeedbackIntent",
+                    "slots": [
+                        {
+                            "name": "FeedbackType",
+                            "type": "FeedbackType",
+                            "samples": [
+                                "Suggesting a new {FeedbackType} ",
+                                "Reporting a {FeedbackType} ",
+                                "I have an {FeedbackType}  for this app",
+                                "Report a {FeedbackType} ",
+                                "{FeedbackType} ",
+                                "I'd like to make a {FeedbackType} ",
+                                "This skill has a {FeedbackType} ",
+                                "There is a {FeedbackType} in the skill",
+                                "There is a {FeedbackType} on the skill",
+                                "I have an {FeedbackType} ",
+                                "I have a {FeedbackType} ",
+                                "I'd like to report a {FeedbackType} "
+                            ]
+                        },
+                        {
+                            "name": "Feedback",
+                            "type": "AMAZON.SearchQuery",
+                            "samples": [
+                                "{Feedback}"
+                            ]
+                        }
+                    ],
+                    "samples": [
+                        "I'd like to suggest something this skill could do",
+                        "I have an idea for this skill",
+                        "I have an idea for this app",
+                        "I have an idea for your app",
+                        "I'd like to report a bug",
+                        "I have a suggestion"
+                    ]
                 }
             ],
-            "types": []
+            "types": [
+                {
+                    "name": "FeedbackType",
+                    "values": [
+                        {
+                            "name": {
+                                "value": "Bug",
+                                "synonyms": [
+                                    "error",
+                                    "Problem"
+                                ]
+                            }
+                        },
+                        {
+                            "name": {
+                                "value": "Idea",
+                                "synonyms": [
+                                    "functionality",
+                                    "feature",
+                                    "Suggestion"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
         },
         "dialog": {
             "intents": [
@@ -1069,6 +1132,32 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "FeedbackIntent",
+                    "confirmationRequired": false,
+                    "prompts": {},
+                    "slots": [
+                        {
+                            "name": "FeedbackType",
+                            "type": "FeedbackType",
+                            "confirmationRequired": true,
+                            "elicitationRequired": true,
+                            "prompts": {
+                                "confirmation": "Confirm.Slot.583949240758.172473885615",
+                                "elicitation": "Elicit.Slot.583949240758.172473885615"
+                            }
+                        },
+                        {
+                            "name": "Feedback",
+                            "type": "AMAZON.SearchQuery",
+                            "confirmationRequired": false,
+                            "elicitationRequired": true,
+                            "prompts": {
+                                "elicitation": "Elicit.Slot.583949240758.1214821999168"
+                            }
+                        }
+                    ]
                 }
             ]
         },
@@ -1097,6 +1186,33 @@
                     {
                         "type": "PlainText",
                         "value": "What's your address?"
+                    }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.583949240758.172473885615",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Are you reporting a bug or suggesting a new feature?"
+                    }
+                ]
+            },
+            {
+                "id": "Confirm.Slot.583949240758.172473885615",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "I heard {FeedbackType} , is that correct?"
+                    }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.583949240758.1214821999168",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "In a few sentences or less, please describe the {FeedbackType}"
                     }
                 ]
             }


### PR DESCRIPTION
Minor changes to the help script, adding the new feedback intent.

Adds the feedback intent. Note that you'll need to add an environment variable (as we do with the google maps api key). The key is "SLACK_WEBHOOKS_URL". I've added the value to our slack channel. Anyone with this URL can send messages to our slack channel with a simple HTTP request.

You can join the `mycity-feedback` channel on the CFB slack to see the feedback.

