### PR TITLE
Add read latest 311 45

### DIFF
--- a/mycity/mycity/intents/latest_311_intent.py
+++ b/mycity/mycity/intents/latest_311_intent.py
@@ -8,10 +8,12 @@ DEFAULT_NUMBER_OF_REPORTS = 3
 BOSTON_311_URL = "https://data.boston.gov/api/3/action/datastore_search"
 BOSTON_RESOURCE_ID = "https://data.boston.gov/api/3/action/datastore_search"
 
+
 def get_311_requests(mycity_request):
     """
     Generates response object for a 311 request inquiry.
 
+    :param mycity_request: MyCityRequestDataModel object
     :return: MyCityResponseDataModel object
     """
     mycity_response = MyCityResponseDataModel()

--- a/mycity/mycity/intents/latest_311_intent.py
+++ b/mycity/mycity/intents/latest_311_intent.py
@@ -1,9 +1,9 @@
 import requests
 from mycity.mycity_response_data_model import MyCityResponseDataModel
 from mycity.intents.custom_errors import BadAPIResponse
-from intents.speech_constants.latest_311_constants import *
+from mycity.intents.speech_constants.latest_311_constants import *
 
-DEFAULT_NUMBER_OF_REQUESTS = 3
+DEFAULT_NUMBER_OF_REPORTS = 3
 
 
 def get_311_requests(mycity_request):
@@ -15,16 +15,12 @@ def get_311_requests(mycity_request):
     mycity_response = MyCityResponseDataModel()
 
     try:
-        number_requests = DEFAULT_NUMBER_OF_REQUESTS
-        if REQUEST_311_NUMBER_REPORTS_SLOT_NAME in \
-                mycity_request.intent_variables:
-            number_requests = \
-                mycity_request.intent_variables[REQUEST_311_NUMBER_REPORTS_SLOT_NAME]["value"]
+        number_reports = number_of_reports(mycity_request)
 
         request_entries = \
-            get_311_requests_from_server(number_requests)
+            get_311_requests_from_server(number_reports)
         mycity_response.output_speech = \
-            REQUEST_311_INTRO_SCRIPT.format(number_requests)
+            REQUEST_311_INTRO_SCRIPT.format(number_reports)
         for request_entry in request_entries:
             mycity_response.output_speech += \
                 build_speech_from_311_report(request_entry)
@@ -35,6 +31,22 @@ def get_311_requests(mycity_request):
         mycity_response.output_speech = BAD_API_RESPONSE
 
     return mycity_response
+
+
+def number_of_reports(mycity_request):
+    """
+    Returns number of reports from the request if available or a default value
+    :param mycity_request: MyCityRequestDataModel object
+    :return: Number of 311 requests to return from this intent
+    """
+    if REQUEST_311_NUMBER_REPORTS_SLOT_NAME in \
+            mycity_request.intent_variables and \
+            "value" in mycity_request.intent_variables[
+                REQUEST_311_NUMBER_REPORTS_SLOT_NAME]:
+        return mycity_request.intent_variables[
+                REQUEST_311_NUMBER_REPORTS_SLOT_NAME]["value"]
+
+    return DEFAULT_NUMBER_OF_REPORTS
 
 
 def get_311_requests_from_server(number_entries):

--- a/mycity/mycity/intents/latest_311_intent.py
+++ b/mycity/mycity/intents/latest_311_intent.py
@@ -5,6 +5,8 @@ from mycity.intents.speech_constants.latest_311_constants import *
 
 DEFAULT_NUMBER_OF_REPORTS = 3
 
+BOSTON_311_URL = "https://data.boston.gov/api/3/action/datastore_search"
+BOSTON_RESOURCE_ID = "https://data.boston.gov/api/3/action/datastore_search"
 
 def get_311_requests(mycity_request):
     """
@@ -69,9 +71,9 @@ def get_raw_311_reports_json(number_entries):
     :param number_entries: Number of entries to return
     :return: JSON object containing 311 data
     """
-    data_url = "https://data.boston.gov/api/3/action/datastore_search"
+    data_url = BOSTON_311_URL
     parameters = {
-        "resource_id": "2968e2c0-d479-49ba-a884-4ef523ada3c0",
+        "resource_id": BOSTON_RESOURCE_ID,
         "limit": number_entries
     }
 

--- a/mycity/mycity/intents/latest_311_intent.py
+++ b/mycity/mycity/intents/latest_311_intent.py
@@ -1,0 +1,92 @@
+import requests
+from mycity.mycity_response_data_model import MyCityResponseDataModel
+from mycity.intents.custom_errors import BadAPIResponse
+from intents.speech_constants.latest_311_constants import *
+
+DEFAULT_NUMBER_OF_REQUESTS = 3
+
+
+def get_311_requests(mycity_request):
+    """
+    Generates response object for a 311 request inquiry.
+
+    :return: MyCityResponseDataModel object
+    """
+    mycity_response = MyCityResponseDataModel()
+
+    try:
+        number_requests = DEFAULT_NUMBER_OF_REQUESTS
+        if REQUEST_311_NUMBER_REPORTS_SLOT_NAME in \
+                mycity_request.intent_variables:
+            number_requests = \
+                mycity_request.intent_variables[REQUEST_311_NUMBER_REPORTS_SLOT_NAME]["value"]
+
+        request_entries = \
+            get_311_requests_from_server(number_requests)
+        mycity_response.output_speech = \
+            REQUEST_311_INTRO_SCRIPT.format(number_requests)
+        for request_entry in request_entries:
+            mycity_response.output_speech += \
+                build_speech_from_311_report(request_entry)
+
+        mycity_response.card_title = REQUEST_311_CARD_TITLE
+
+    except BadAPIResponse:
+        mycity_response.output_speech = BAD_API_RESPONSE
+
+    return mycity_response
+
+
+def get_311_requests_from_server(number_entries):
+    """
+    Returns the 311 data of the latest number_entries of requests to Boston's
+    311
+
+    :param number_entries: Number of entries to return
+    :return: JSON object containing array of 311 requests.
+    """
+
+    response_json = get_raw_311_reports_json(number_entries)
+    return response_json["result"]["records"]
+
+
+def get_raw_311_reports_json(number_entries):
+    """
+    Returns the JSON object from the 311 API
+
+    :param number_entries: Number of entries to return
+    :return: JSON object containing 311 data
+    """
+    data_url = "https://data.boston.gov/api/3/action/datastore_search"
+    parameters = {
+        "resource_id": "2968e2c0-d479-49ba-a884-4ef523ada3c0",
+        "limit": number_entries
+    }
+
+    response = requests.get(data_url, parameters)
+    if response.status_code != requests.codes.ok:
+        raise BadAPIResponse
+
+    if "result" not in response.json() or \
+            "records" not in response.json()["result"]:
+        # Unexpected JSON format. Missing expected keys
+        raise BadAPIResponse
+
+    return response.json()
+
+
+def build_speech_from_311_report(report):
+    """
+    Builds a speech string from a given 311 report
+    :param report: JSON object of a single 311 report
+    :return: Speech string representing this report
+    """
+
+    try:
+        subject = report["SUBJECT"]
+        report_type = report["TYPE"]
+        location = report["LOCATION_STREET_NAME"]
+    except KeyError:
+        raise BadAPIResponse
+
+    return REQUEST_311_REPORT_SCRIPT.format(location, subject, report_type)

--- a/mycity/mycity/intents/speech_constants/latest_311_constants.py
+++ b/mycity/mycity/intents/speech_constants/latest_311_constants.py
@@ -1,0 +1,10 @@
+""" Constants used to respond to latest 311 requests"""
+
+REQUEST_311_NUMBER_REPORTS_SLOT_NAME = "number_requests"
+
+BAD_API_RESPONSE = "Something went wrong. Try again later."
+REQUEST_311_INTRO_SCRIPT = "Here are the {} latest three one one reports: "
+REQUEST_311_REPORT_SCRIPT = \
+    "There was a request at {} for the {} to address {}. "
+REQUEST_311_CARD_TITLE = "311 Reports"
+

--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -8,7 +8,7 @@ from mycity.mycity_response_data_model import MyCityResponseDataModel
 from .intents.user_address_intent import set_address_in_session, \
     get_address_from_session, request_user_address_response, \
     set_zipcode_in_session, get_address_from_user_device
-from mycity.intents.latest_311_intent import get_311_requests
+from .intents.latest_311_intent import get_311_requests
 from .intents.trash_intent import get_trash_day_info
 from .intents.unhandled_intent import unhandled_intent
 from .intents.get_alerts_intent import get_alerts_intent

--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -8,7 +8,7 @@ from mycity.mycity_response_data_model import MyCityResponseDataModel
 from .intents.user_address_intent import set_address_in_session, \
     get_address_from_session, request_user_address_response, \
     set_zipcode_in_session, get_address_from_user_device
-from .intents.latest_311_intent import get_311_requests
+from mycity.intents.latest_311_intent import get_311_requests
 from .intents.trash_intent import get_trash_day_info
 from .intents.unhandled_intent import unhandled_intent
 from .intents.get_alerts_intent import get_alerts_intent

--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -8,6 +8,7 @@ from mycity.mycity_response_data_model import MyCityResponseDataModel
 from .intents.user_address_intent import set_address_in_session, \
     get_address_from_session, request_user_address_response, \
     set_zipcode_in_session, get_address_from_user_device
+from mycity.intents.latest_311_intent import get_311_requests
 from .intents.trash_intent import get_trash_day_info
 from .intents.unhandled_intent import unhandled_intent
 from .intents.get_alerts_intent import get_alerts_intent
@@ -133,6 +134,8 @@ def on_intent(mycity_request):
         return submit_feedback(mycity_request)
     elif mycity_request.intent_name == "UnhandledIntent":
         return unhandled_intent(mycity_request)
+    elif mycity_request.intent_name == "LatestThreeOneOne":
+        return get_311_requests(mycity_request)
     else:
         raise ValueError("Invalid intent")
 

--- a/mycity/mycity/test/integration_tests/test_latest_311_intent.py
+++ b/mycity/mycity/test/integration_tests/test_latest_311_intent.py
@@ -1,0 +1,73 @@
+import unittest.mock as mock
+import mycity.intents.speech_constants.latest_311_constants \
+    as intent_constants
+import mycity.test.integration_tests.intent_test_mixins as mix_ins
+import mycity.test.integration_tests.intent_base_case as base_case
+from mycity.test.test_data.latest_311_fake_data import *
+
+
+class Latest311TestCase(mix_ins.RepromptTextTestMixIn,
+                        mix_ins.CardTitleTestMixIn,
+                        mix_ins.CorrectSpeechOutputTestMixIn,
+                        base_case.IntentBaseCase):
+
+    intent_to_test = "LatestThreeOneOne"
+    expected_title = intent_constants.REQUEST_311_CARD_TITLE
+    returns_reprompt_text = False
+    expected_card_title = intent_constants.REQUEST_311_CARD_TITLE
+
+    def setUp(self):
+        """
+        Set up unit tests by mocking calls to 311
+        """
+        super().setUp()
+        self.mock_311_service = mock.patch(
+            'mycity.intents.latest_311_intent.get_raw_311_reports_json',
+            return_value=FAKE_JSON_RESPONSE_3).start()
+
+    def tearDown(self):
+        """
+        Stop mocked objects
+        """
+        super().tearDown()
+        self.mock_311_service.stop()
+
+    def test_slot_determines_number_of_reports(self):
+        num_reports = 1
+        self.request.intent_variables = \
+            {
+                intent_constants.REQUEST_311_NUMBER_REPORTS_SLOT_NAME:
+                    {"value": num_reports}
+            }
+        self.mock_311_service.return_value = FAKE_JSON_RESPONSE_1
+        response = self.controller.on_intent(self.request)
+        self.mock_311_service.assert_called_once_with(num_reports)
+        self.assertTrue(FAKE_LOCATION_1 in response.output_speech)
+        self.assertTrue(FAKE_TYPE_1 in response.output_speech)
+        self.assertTrue(FAKE_SUBJECT_1 in response.output_speech)
+
+    def test_speech_can_contain_multiple_reports(self):
+        num_reports = 3
+        self.request.intent_variables = \
+            {
+                intent_constants.REQUEST_311_NUMBER_REPORTS_SLOT_NAME:
+                    {"value": num_reports}
+            }
+        self.mock_311_service.return_value = FAKE_JSON_RESPONSE_3
+        response = self.controller.on_intent(self.request)
+        self.mock_311_service.assert_called_once_with(num_reports)
+
+        # Data group 1
+        self.assertTrue(FAKE_LOCATION_1 in response.output_speech)
+        self.assertTrue(FAKE_TYPE_1 in response.output_speech)
+        self.assertTrue(FAKE_SUBJECT_1 in response.output_speech)
+
+        # Data group 1
+        self.assertTrue(FAKE_LOCATION_2 in response.output_speech)
+        self.assertTrue(FAKE_TYPE_2 in response.output_speech)
+        self.assertTrue(FAKE_SUBJECT_2 in response.output_speech)
+
+        # Data group 1
+        self.assertTrue(FAKE_LOCATION_3 in response.output_speech)
+        self.assertTrue(FAKE_TYPE_3 in response.output_speech)
+        self.assertTrue(FAKE_SUBJECT_3 in response.output_speech)

--- a/mycity/mycity/test/test_data/latest_311_fake_data.py
+++ b/mycity/mycity/test/test_data/latest_311_fake_data.py
@@ -1,0 +1,50 @@
+"""
+Data used for testing latest 311 intent
+"""
+
+FAKE_SUBJECT_1 = "Public Health Department"
+FAKE_TYPE_1 = "Eating Plain M and Ms"
+FAKE_LOCATION_1 = "Jamie's House"
+FAKE_JSON_DATA_1 = {
+    "SUBJECT": FAKE_SUBJECT_1,
+    "TYPE": FAKE_TYPE_1,
+    "LOCATION_STREET_NAME": FAKE_LOCATION_1,
+}
+
+FAKE_SUBJECT_2 = "Police Issues"
+FAKE_TYPE_2 = "Loud Metal Music"
+FAKE_LOCATION_2 = "Jason's House"
+FAKE_JSON_DATA_2 = {
+    "SUBJECT": FAKE_SUBJECT_2,
+    "TYPE": FAKE_TYPE_2,
+    "LOCATION_STREET_NAME": FAKE_LOCATION_2,
+}
+
+FAKE_SUBJECT_3 = "Parks and Recreation"
+FAKE_TYPE_3 = "Streaming Movies Since The Downfall Of MoviePass"
+FAKE_LOCATION_3 = "Josh's House"
+FAKE_JSON_DATA_3 = {
+    "SUBJECT": FAKE_SUBJECT_3,
+    "TYPE": FAKE_TYPE_3,
+    "LOCATION_STREET_NAME": FAKE_LOCATION_3,
+}
+
+FAKE_JSON_RESPONSE_1 =\
+    {
+        "result": {
+            "records": [
+              FAKE_JSON_DATA_1
+            ]
+        }
+    }
+
+FAKE_JSON_RESPONSE_3 = \
+    {
+        "result": {
+            "records": [
+                FAKE_JSON_DATA_1,
+                FAKE_JSON_DATA_2,
+                FAKE_JSON_DATA_3
+            ]
+        }
+    }

--- a/mycity/platforms/amazon/models/en_US.json
+++ b/mycity/platforms/amazon/models/en_US.json
@@ -1063,6 +1063,32 @@
                         "I'd like to report a bug",
                         "I have a suggestion"
                     ]
+                },
+                {
+                    "name": "LatestThreeOneOne",
+                    "slots": [
+                        {
+                            "name": "number_requests",
+                            "type": "AMAZON.NUMBER"
+                        }
+                    ],
+                    "samples": [
+                        "What are the {number_requests} latest problems",
+                        "Give me {number_requests} three one one",
+                        "{number_requests} three one one reports",
+                        "{number_requests} three one one",
+                        "What are the latest {number_requests} from three one one",
+                        "Read me {number_requests} three one one requets",
+                        "Read me three one one requests",
+                        "What are some problems in the city",
+                        "What issues have been reported",
+                        "What has been reported to the city",
+                        "Whats has been reported",
+                        "Three one one requests",
+                        "Three one one reports",
+                        "What are the latest from three one one",
+                        "Give me the three one one"
+                    ]
                 }
             ],
             "types": [


### PR DESCRIPTION
Closes #45 

Adds an intent to read the latest 311 reports. Defaults to 3 reports, but user can specify a particular number if they want.