### PR TITLE
Match case in SQL database when making a crime incident query

### DIFF
--- a/mycity/mycity/utilities/crime_incidents_api_utils.py
+++ b/mycity/mycity/utilities/crime_incidents_api_utils.py
@@ -43,8 +43,8 @@ def _build_query_string(address):
 
     """
     coordinates = _get_coordinates_for_address(address)
-    return """SELECT * FROM "{}" WHERE "Lat" LIKE '{}%' AND \
-        "Long" LIKE '{}%' LIMIT {}""" \
+    return """SELECT * FROM "{}" WHERE "lat" LIKE '{}%' AND \
+        "long" LIKE '{}%' LIMIT {}""" \
         .format(RESOURCEID, coordinates[0], coordinates[1], QUERY_LIMIT)
 
 


### PR DESCRIPTION
Update the crime incident SQL query to match the column name's case. Not sure why this broke now, but likely a change to the SQL database. 

Closes #191 