### PR TITLE
test runner fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ pip-selfcheck.json
 
 selenium/*
 
+venv/
+
 # Logs
 logs
 *.log

--- a/mycity/run_tests.sh
+++ b/mycity/run_tests.sh
@@ -1,8 +1,12 @@
-# Dummy variables must be set in order to avoid KeyError being raised during testing
 
 # see issue #187 to determine if GOOGLE_MAPS_API can be removed along with this comment.
-export GOOGLE_MAPS_API_KEY=FAKEFAKEFAKE
+if [ -z "${GOOGLE_MAPS_API_KEY}" ];then
+    export GOOGLE_MAPS_API_KEY=FAKEFAKEFAKE
+fi
 
-export SLACK_WEBHOOKS_URL=FAKEFAKEFAKE
+if [ -z "${SLACK_WEBHOOKS_URL}" ]; then
+    export SLACK_WEBHOOKS_URL=FAKEFAKEFAKE
+fi
 
 python -m unittest discover -v -s mycity/test
+

--- a/mycity/run_tests.sh
+++ b/mycity/run_tests.sh
@@ -1,1 +1,8 @@
+# Dummy variables must be set in order to avoid KeyError being raised during testing
+
+# see issue #187 to determine if GOOGLE_MAPS_API can be removed along with this comment.
+export GOOGLE_MAPS_API_KEY=FAKEFAKEFAKE
+
+export SLACK_WEBHOOKS_URL=FAKEFAKEFAKE
+
 python -m unittest discover -v -s mycity/test


### PR DESCRIPTION
a quick change to `run_tests.sh` to solve environmental variable KeyError problem.

fixes #199 