### PR TITLE
Update food_truck_intent respones time (#220)

### DIFF
--- a/mycity/mycity/intents/food_truck_intent.py
+++ b/mycity/mycity/intents/food_truck_intent.py
@@ -39,7 +39,7 @@ def add_response_text(food_trucks):
         t = food_trucks[x]
         open_hours = str(t['attributes']['Hours']).replace("-", "and")
         response += f"{t['attributes']['Truck']} is located" \
-            f" at {t['attributes']['Location']} between {open_hours},"
+            f" at {t['attributes']['Location']} between {open_hours} ."
     return response
 
 

--- a/mycity/mycity/intents/food_truck_intent.py
+++ b/mycity/mycity/intents/food_truck_intent.py
@@ -103,23 +103,20 @@ def get_nearby_food_trucks(mycity_request):
 
             if len(truck_unique_locations) == 1:
                 response = f"I found {len(truck_unique_locations)} food " \
-                           f"truck within a mile " \
-                           "from your address! "
+                           f"truck within a mile from your address! "
                 response += add_response_text(truck_unique_locations)
                 mycity_response.output_speech = response
 
             if 1 < len(truck_unique_locations) <= 3:
                 response = f"I found {len(truck_unique_locations)} food " \
-                           f"trucks within a mile " \
-                           "from your address! "
+                           f"trucks within a mile from your address! "
                 response += add_response_text(truck_unique_locations)
                 mycity_response.output_speech = response
 
             if len(truck_unique_locations) > 3:
                 response = f"There are at least {len(truck_unique_locations)}" \
                            f" food trucks within a mile from your " \
-                           f"address! Here are the first " \
-                           + str(len(truck_unique_locations)) + ". "
+                           f"address! Here are the first five. "
                 response += add_response_text(truck_unique_locations)
                 mycity_response.output_speech = response
 

--- a/mycity/mycity/intents/food_truck_intent.py
+++ b/mycity/mycity/intents/food_truck_intent.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 MILE = 1600
 BASE_URL = 'https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/' \
-               'services/food_trucks_schedule/FeatureServer/0/'
+               'services/food_truck_schedule/FeatureServer/0/'
 DAY = date.get_day()
 FOOD_TRUCK_LIMIT = 5  # limits the number of food trucks
 CARD_TITLE = "Food Trucks"
@@ -37,10 +37,9 @@ def add_response_text(food_trucks):
     response = ''
     for x in range(length):
         t = food_trucks[x]
+        open_hours = str(t['attributes']['Hours']).replace("-", "and")
         response += f"{t['attributes']['Truck']} is located" \
-            f" at {t['attributes']['Loc']} between " \
-            f"{t['attributes']['Start_time']} and " \
-            f"{t['attributes']['End_time']}, "
+            f" at {t['attributes']['Location']} between {open_hours},"
     return response
 
 

--- a/mycity/mycity/intents/food_truck_intent.py
+++ b/mycity/mycity/intents/food_truck_intent.py
@@ -18,14 +18,25 @@ logger = logging.getLogger(__name__)
 MILE = 1600
 BASE_URL = 'https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/' \
                'services/food_trucks_schedule/FeatureServer/0/'
-QUERY = {'where': '1=1', 'out_sr': '4326'}
 DAY = date.get_day()
 FOOD_TRUCK_LIMIT = 5  # limits the number of food trucks
+CARD_TITLE = "Food Trucks"
+QUERY = {
+    "distance": "1",
+    "inSR": "4326",
+    "outSR": "4326",
+    "f": "json",
+    "outfields": "*",
+    "units": "esriSRUnit_StatuteMile",
+    "geometryType": "esriGeometryPoint"
+}
 
 
 def add_response_text(food_trucks):
+    length = min(FOOD_TRUCK_LIMIT, len(food_trucks))
     response = ''
-    for t in food_trucks:
+    for x in range(length):
+        t = food_trucks[x]
         response += f"{t['attributes']['Truck']} is located" \
             f" at {t['attributes']['Loc']} between " \
             f"{t['attributes']['Start_time']} and " \
@@ -33,12 +44,19 @@ def add_response_text(food_trucks):
     return response
 
 
-def get_truck_locations():
+def get_truck_locations(given_address):
     """
-    Get the location of the food trucks in Boston TODAY
+    Get the location of the food trucks in Boston TODAY within 1 mile
+    of a given_address
 
     :return: a list of features with unique food truck locations
     """
+    formatted_address = '{x_coordinate}, {y_coordinate}'.format(
+        x_coordinate=given_address['x'],
+        y_coordinate=given_address['y']
+    )
+    QUERY["geometry"] = formatted_address
+
     trucks = gis_utils.get_features_from_feature_server(BASE_URL, QUERY)
     truck_unique_locations = []
     for t in trucks:
@@ -76,42 +94,33 @@ def get_nearby_food_trucks(mycity_request):
 
         # Get user's GIS Geocode Address and list of available trucks
         usr_addr = gis_utils.geocode_address(address)
-        truck_unique_locations = get_truck_locations()
-        nearby_food_trucks = []
+        truck_unique_locations = get_truck_locations(usr_addr)
 
+        # Create custom response based on number of trucks returned
         try:
-            # Loop through food truck list and search for nearby food trucks
-            # limit to 5 to speed up response
-            counter = 0
-            for t in truck_unique_locations:
-                dist = gis_utils.calculate_distance(usr_addr, t)
-                if dist <= MILE:
-                    nearby_food_trucks.append(t)
-                    counter += 1
-                    if counter == FOOD_TRUCK_LIMIT:
-                        break
-
-            count = len(nearby_food_trucks)
-            if count == 0:
+            if len(truck_unique_locations) == 0:
                 mycity_response.output_speech = "I didn't find any food trucks!"
 
-            if count == 1:
-                response = f"I found {count} food truck within a mile " \
-                    "from your address! "
-                response += add_response_text(nearby_food_trucks)
+            if len(truck_unique_locations) == 1:
+                response = f"I found {len(truck_unique_locations)} food " \
+                           f"truck within a mile " \
+                           "from your address! "
+                response += add_response_text(truck_unique_locations)
                 mycity_response.output_speech = response
 
-            if 1 < count <= 3:
-                response = f"I found {count} food trucks within a mile " \
-                    "from your address! "
-                response += add_response_text(nearby_food_trucks)
+            if 1 < len(truck_unique_locations) <= 3:
+                response = f"I found {len(truck_unique_locations)} food " \
+                           f"trucks within a mile " \
+                           "from your address! "
+                response += add_response_text(truck_unique_locations)
                 mycity_response.output_speech = response
 
-            elif count > 3:
-                response = f"There are at least {count} food trucks within " \
-                           f"a mile from your address! Here are the first " \
-                           + str(count) + ". "
-                response += add_response_text(nearby_food_trucks)
+            if len(truck_unique_locations) > 3:
+                response = f"There are at least {len(truck_unique_locations)}" \
+                           f" food trucks within a mile from your " \
+                           f"address! Here are the first " \
+                           + str(len(truck_unique_locations)) + ". "
+                response += add_response_text(truck_unique_locations)
                 mycity_response.output_speech = response
 
         except InvalidAddressError:
@@ -125,7 +134,7 @@ def get_nearby_food_trucks(mycity_request):
             mycity_response.reprompt_text = None
             mycity_response.session_attributes = \
                 mycity_request.session_attributes
-            mycity_response.card_title = "Food Trucks"
+            mycity_response.card_title = CARD_TITLE
             mycity_request = clear_address_from_mycity_object(mycity_request)
             mycity_response = clear_address_from_mycity_object(mycity_response)
             return mycity_response
@@ -149,6 +158,6 @@ def get_nearby_food_trucks(mycity_request):
     # understood, the session will end.
     mycity_response.reprompt_text = None
     mycity_response.session_attributes = mycity_request.session_attributes
-    mycity_response.card_title = "Food Trucks"
+    mycity_response.card_title = CARD_TITLE
 
     return mycity_response

--- a/mycity/mycity/test/integration_tests/test_food_truck_intent.py
+++ b/mycity/mycity/test/integration_tests/test_food_truck_intent.py
@@ -1,0 +1,39 @@
+import unittest.mock as mock
+import mycity.test.test_constants as test_constants
+import mycity.test.integration_tests.intent_base_case as base_case
+import mycity.test.integration_tests.intent_test_mixins as mix_ins
+import mycity.intents.food_truck_intent as food_truck_intent
+
+
+###################################
+# TestCase class for trash_intent #
+###################################
+
+class FoodTruckTestCase(mix_ins.RepromptTextTestMixIn,
+                       mix_ins.CardTitleTestMixIn,
+                       mix_ins.CorrectSpeechOutputTestMixIn,
+                       base_case.IntentBaseCase):
+
+    intent_to_test = "FoodTruckIntent"
+    expected_title = food_truck_intent.CARD_TITLE
+    returns_reprompt_text = False
+    expected_card_title = food_truck_intent.CARD_TITLE
+
+    def setUp(self):
+        """
+        Patching out the functions in FoodTruckIntent that use requests.get
+        """
+        super().setUp()
+        self.get_address_api_patch = \
+            mock.patch('mycity.intents.trash_intent.get_address_api_info',
+                       return_value = test_constants.GET_ADDRESS_API_MOCK)
+        self.get_truck_locations_patch = \
+            mock.patch('mycity.intents.trash_intent.get_trash_day_data',
+                       return_value = test_constants.GET_FOOD_TRUCKS_MOCK)
+        self.get_address_api_patch.start()
+        self.get_truck_locations_patch.start()
+
+    def tearDown(self):
+        super().tearDown()
+        self.get_address_api_patch.stop()
+        self.get_truck_locations_patch.stop()

--- a/mycity/mycity/test/integration_tests/test_food_truck_intent.py
+++ b/mycity/mycity/test/integration_tests/test_food_truck_intent.py
@@ -10,9 +10,9 @@ import mycity.intents.food_truck_intent as food_truck_intent
 ###################################
 
 class FoodTruckTestCase(mix_ins.RepromptTextTestMixIn,
-                       mix_ins.CardTitleTestMixIn,
-                       mix_ins.CorrectSpeechOutputTestMixIn,
-                       base_case.IntentBaseCase):
+                        mix_ins.CardTitleTestMixIn,
+                        mix_ins.CorrectSpeechOutputTestMixIn,
+                        base_case.IntentBaseCase):
 
     intent_to_test = "FoodTruckIntent"
     expected_title = food_truck_intent.CARD_TITLE
@@ -26,10 +26,10 @@ class FoodTruckTestCase(mix_ins.RepromptTextTestMixIn,
         super().setUp()
         self.get_address_api_patch = \
             mock.patch('mycity.intents.trash_intent.get_address_api_info',
-                       return_value = test_constants.GET_ADDRESS_API_MOCK)
+                       return_value=test_constants.GET_ADDRESS_API_MOCK)
         self.get_truck_locations_patch = \
             mock.patch('mycity.intents.trash_intent.get_trash_day_data',
-                       return_value = test_constants.GET_FOOD_TRUCKS_MOCK)
+                       return_value=test_constants.GET_FOOD_TRUCKS_MOCK)
         self.get_address_api_patch.start()
         self.get_truck_locations_patch.start()
 

--- a/mycity/mycity/test/test_constants.py
+++ b/mycity/mycity/test/test_constants.py
@@ -867,7 +867,7 @@ GEOCODE_ADDRESS_CANDIDATES = {
 
 TOP_ADDRESS_CANDIDATE = {
         'address': '1000 Dorchester Ave, Dorchester, Massachusetts, 02125',
-        'x': -71.05664413015762, 
+        'x': -71.05664413015762,
         'y': 42.31649037829649}
 
 ARCGIS_CLOSEST_DESTINATION = {'Address': '8-20 Belden St Boston, MA', 'Driving_time': '3.65 minutes', 'Driving_distance': '0.73 miles'}
@@ -896,3 +896,175 @@ GET_CRIME_INCIDENTS_API_MOCK = {
 }
 
 GEOCODE_ADDRESS_MOCK = [42.35351814, -71.13117064]
+
+# Food Truck Intent
+GET_FOOD_TRUCKS_MOCK = [
+    {
+        "attributes": {
+            "FID": 159,
+            "Time": "Lunch",
+            "Day": "Monday",
+            "Truck": "Taco Don Beto",
+            "Loc": "Harrison Avenue",
+            "Hours": "11 a.m. - 3 p.m.",
+            "Title": "Boston Medical Center",
+            "Site_num": 11,
+            "Management": "City of Boston",
+            "Notes": " ",
+            "POINT_X": -7911820.41299,
+            "POINT_Y": 5211547.53614,
+            "Link": "https://www.boston.gov/departments/small-business-development/city-boston-food-trucks-schedule",
+            "Start_time": "11:00:00 AM",
+            "End_time": "3:00:00 PM",
+            "GlobalID": "d026b595-a4ee-4d92-ad22-401dc3e44a73",
+            "CreationDate": 1520268574231,
+            "Creator": "143525_boston",
+            "EditDate": 1522697895524,
+            "Editor": "143525_boston"
+        },
+        "geometry": {
+            "x": -71.073092022067257,
+            "y": 42.336685825960636
+        }
+    },
+    {
+        "attributes": {
+            "FID": 160,
+            "Time": "Lunch",
+            "Day": "Tuesday",
+            "Truck": "Fat Chowda",
+            "Loc": "Harrison Avenue",
+            "Hours": "11 a.m. - 3 p.m.",
+            "Title": "Boston Medical Center",
+            "Site_num": 11,
+            "Management": "City of Boston",
+            "Notes": " ",
+            "POINT_X": -7911820.41299,
+            "POINT_Y": 5211547.53614,
+            "Link": "https://twitter.com/fatchowda?lang=en",
+            "Start_time": "11:00:00 AM",
+            "End_time": "3:00:00 PM",
+            "GlobalID": "d45412ba-ce97-4bfe-a1bc-6b7a9f486a63",
+            "CreationDate": 1520268574231,
+            "Creator": "143525_boston",
+            "EditDate": 1522695459727,
+            "Editor": "143525_boston"
+        },
+        "geometry": {
+            "x": -71.073092022067257,
+            "y": 42.336685825960636
+        }
+    },
+    {
+        "attributes": {
+            "FID": 161,
+            "Time": "Lunch",
+            "Day": "Tuesday",
+            "Truck": "Tandoor and Curry",
+            "Loc": "Harrison Avenue",
+            "Hours": "11 a.m. - 3 p.m.",
+            "Title": "Boston Medical Center",
+            "Site_num": 11,
+            "Management": "City of Boston",
+            "Notes": " ",
+            "POINT_X": -7911820.41299,
+            "POINT_Y": 5211547.53614,
+            "Link": "https://tandoorandcurryonwheels.com/",
+            "Start_time": "11:00:00 AM",
+            "End_time": "3:00:00 PM",
+            "GlobalID": "54e455d1-fa6e-46a7-8843-8392af151ee9",
+            "CreationDate": 1520268574231,
+            "Creator": "143525_boston",
+            "EditDate": 1522687154711,
+            "Editor": "143525_boston"
+        },
+        "geometry": {
+            "x": -71.073092022067257,
+            "y": 42.336685825960636
+        }
+    },
+    {
+        "attributes": {
+            "FID": 162,
+            "Time": "Lunch",
+            "Day": "Wednesday",
+            "Truck": "Pomaire Chilean",
+            "Loc": "Harrison Avenue",
+            "Hours": "11 a.m. - 3 p.m.",
+            "Title": "Boston Medical Center",
+            "Site_num": 11,
+            "Management": "City of Boston",
+            "Notes": " ",
+            "POINT_X": -7911820.41299,
+            "POINT_Y": 5211547.53614,
+            "Link": "http://pomairefoodtruck.com/?_sm_nck=1",
+            "Start_time": "11:00:00 AM",
+            "End_time": "3:00:00 PM",
+            "GlobalID": "0014aba5-b529-4ece-8a11-355541e36652",
+            "CreationDate": 1520268574231,
+            "Creator": "143525_boston",
+            "EditDate": 1522689060795,
+            "Editor": "143525_boston"
+        },
+        "geometry": {
+            "x": -71.073092022067257,
+            "y": 42.336685825960636
+        }
+    },
+    {
+        "attributes": {
+            "FID": 163,
+            "Time": "Lunch",
+            "Day": "Wednesday",
+            "Truck": "Mediterranean Home Cooking",
+            "Loc": "Harrison Avenue",
+            "Hours": "11 a.m. - 3 p.m.",
+            "Title": "Boston Medical Center",
+            "Site_num": 11,
+            "Management": "City of Boston",
+            "Notes": " ",
+            "POINT_X": -7911820.41299,
+            "POINT_Y": 5211547.53614,
+            "Link": "https://www.facebook.com/Mediterranean-Home-Cooking-440428386060916/",
+            "Start_time": "11:00:00 AM",
+            "End_time": "3:00:00 PM",
+            "GlobalID": "6426fecb-6aa3-45f3-a1c4-8d9b5c054e82",
+            "CreationDate": 1520268574231,
+            "Creator": "143525_boston",
+            "EditDate": 1522695522352,
+            "Editor": "143525_boston"
+        },
+        "geometry": {
+            "x": -71.073092022067257,
+            "y": 42.336685825960636
+        }
+    },
+    {
+        "attributes": {
+            "FID": 164,
+            "Time": "Lunch",
+            "Day": "Thursday",
+            "Truck": "Big Daddy Hotdogs",
+            "Loc": "Harrison Avenue",
+            "Hours": "11 a.m. - 3 p.m.",
+            "Title": "Boston Medical Center",
+            "Site_num": 11,
+            "Management": "City of Boston",
+            "Notes": " ",
+            "POINT_X": -7911820.41299,
+            "POINT_Y": 5211547.53614,
+            "Link": "https://www.facebook.com/bigdaddyhotdogscopley/",
+            "Start_time": "11:00:00 AM",
+            "End_time": "3:00:00 PM",
+            "GlobalID": "d34179fa-27fb-42f6-be8e-2ee735b36062",
+            "CreationDate": 1520268574231,
+            "Creator": "143525_boston",
+            "EditDate": 1522777085406,
+            "Editor": "143525_boston"
+        },
+        "geometry": {
+            "x": -71.073092022067257,
+            "y": 42.336685825960636
+        }
+    }
+]


### PR DESCRIPTION
For issue #220 

The food truck intent was taking a relatively long time to run and process, and was requiring people to locally increase their lambda timeout period in order to use it.  This was because previously we were querying arcGIS for all of the food trucks in Boston and then having to search for those within a mile of the given address by iterating over the list.  Even with only returning the first 5 food trucks found the request was our longest.

By working with others we were able to update our query to arcGIS to automatically filter out any food truck farther than a given distance from the address (currently 1 mile) and we can now simple return all food trucks or still just the first five.  This increase in speed should also allow other improvements to occur (such as those suggested in #221) 

Also there was no food_truck_intent test file; I added one. 