### PR TITLE
Add instructions to ask for help in the launch request and add all features to the help speech

### DIFF
--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -190,8 +190,9 @@ def get_help_response(mycity_request):
         "You are using Boston Info, a skill that provides information "
         "about Boston services and alerts. You can ask about your trash "
         "pickup schedule, city alerts, the locations of food trucks "
-        "and farmers markets, info about snow emergencies, and more! If you have feedback for the "
-        "skill, say, 'I have a suggestion.'"
+        "and farmers markets, info about snow emergencies, the latest "\
+        "three one one reports, and the latest crime reports! "\
+        "If you have feedback for the skill, say, 'I have a suggestion.'"
      )
     mycity_response.reprompt_text = None
     mycity_response.should_end_session = False
@@ -215,7 +216,9 @@ def get_welcome_response(mycity_request):
     mycity_response.session_attributes = mycity_request.session_attributes
     mycity_response.card_title = "Welcome"
     mycity_response.output_speech = \
-        "Welcome to the Boston Info skill. How can I help you? "
+        "Welcome to the Boston Info skill. You can ask for help at any time, and I'll "\
+        "let you know what information I can provide. "\
+        "How can I help you?"
 
     # If the user either does not reply to the welcome message or says
     # something that is not understood, they will be prompted again with

--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -23,6 +23,20 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+LAUNCH_SPEECH = "Welcome to the Boston Info skill. You can ask for help at any time, and I'll "\
+    "let you know what information I can provide. "\
+    "How can I help you?"
+
+LAUNCH_REPROMPT_SPEECH = "You can ask me about Boston city services, "\
+    "such as \"are there any city alerts\"?"
+
+HELP_SPEECH = "You are using Boston Info, a skill that provides information " \
+        "about Boston services and alerts. You can ask about your trash " \
+        "pickup schedule, city alerts, the locations of food trucks " \
+        "and farmers markets, info about snow emergencies, the latest "\
+        "three one one reports, and the latest crime reports! "\
+        "If you have feedback for the skill, say, 'I have a suggestion.'"
+
 
 def execute_request(mycity_request):
     """
@@ -186,14 +200,7 @@ def get_help_response(mycity_request):
     mycity_response = MyCityResponseDataModel()
     mycity_response.session_attributes = mycity_request.session_attributes
     mycity_response.card_title = "Help"
-    mycity_response.output_speech = (
-        "You are using Boston Info, a skill that provides information "
-        "about Boston services and alerts. You can ask about your trash "
-        "pickup schedule, city alerts, the locations of food trucks "
-        "and farmers markets, info about snow emergencies, the latest "\
-        "three one one reports, and the latest crime reports! "\
-        "If you have feedback for the skill, say, 'I have a suggestion.'"
-     )
+    mycity_response.output_speech = HELP_SPEECH
     mycity_response.reprompt_text = None
     mycity_response.should_end_session = False
     return mycity_response
@@ -215,17 +222,12 @@ def get_welcome_response(mycity_request):
     mycity_response = MyCityResponseDataModel()
     mycity_response.session_attributes = mycity_request.session_attributes
     mycity_response.card_title = "Welcome"
-    mycity_response.output_speech = \
-        "Welcome to the Boston Info skill. You can ask for help at any time, and I'll "\
-        "let you know what information I can provide. "\
-        "How can I help you?"
+    mycity_response.output_speech = LAUNCH_SPEECH
 
     # If the user either does not reply to the welcome message or says
     # something that is not understood, they will be prompted again with
     # this text.
-    mycity_response.reprompt_text = \
-        "You can ask me about Boston city services, "\
-        "such as \"are there any city alerts\"?"
+    mycity_response.reprompt_text = LAUNCH_REPROMPT_SPEECH
     mycity_response.should_end_session = False
     return mycity_response
 

--- a/mycity/mycity/test/unit_tests/test_mycity_controller.py
+++ b/mycity/mycity/test/unit_tests/test_mycity_controller.py
@@ -26,14 +26,8 @@ class MyCityControllerUnitTestCase(base.BaseTestCase):
     def test_on_launch(self):
         self.request.is_new_session = False
         expected_session_attributes = self.request.session_attributes
-        expected_output_speech = (
-            "Welcome to the Boston Info skill. "
-            "How can I help you? "
-        )
-        expected_reprompt_text = (
-            "You can ask me about Boston city services, "\
-            "such as \"are there any city alerts\"?"
-        )
+        expected_output_speech = my_con.LAUNCH_SPEECH
+        expected_reprompt_text = my_con.LAUNCH_REPROMPT_SPEECH
         expected_card_title = "Welcome"
         response = self.controller.on_launch(self.request)
         self.assertEqual(


### PR DESCRIPTION
Closes #230 

Minor text changes to give the user instructions on how to get help and a list of all available features. 