### PR TITLE
Remove SetAddressIntent

### DIFF
--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -114,10 +114,6 @@ def on_intent(mycity_request):
 
     logger.debug('MyCityRequestDataModel received:' + mycity_request.get_logger_string())
 
-    if mycity_request.intent_name == "SetAddressIntent":
-        set_address_in_session(mycity_request)
-        return get_address_from_session(mycity_request)
-
     if "Address" in mycity_request.intent_variables \
             and "value" in mycity_request.intent_variables["Address"]:
         # Some of our intents have an associated address value.

--- a/mycity/mycity/test/unit_tests/test_mycity_controller.py
+++ b/mycity/mycity/test/unit_tests/test_mycity_controller.py
@@ -58,24 +58,6 @@ class MyCityControllerUnitTestCase(base.BaseTestCase):
         self.assertEqual(response.card_title, expected_card_title)
         self.assertIsNone(response.reprompt_text)
 
-    # if we change how we import intents in mycity_controller I think it will
-    # break these patches
-    @mock.patch('mycity.mycity_controller.set_address_in_session')
-    def test_set_address_intent_no_address_prompted(self, mock_set_address):
-        self.request.is_new_session = False
-        self.request.intent_name = "SetAddressIntent"
-        self.controller.on_intent(self.request)
-        mock_set_address.assert_called_with(self.request)
-   
-    @mock.patch('mycity.mycity_controller.get_address_from_session')
-    def test_set_address_intent_no_address_in_session_attributes(
-            self,
-            mock_get_addr
-    ):
-        self.request.intent_name = "SetAddressIntent"
-        self.controller.on_intent(self.request)
-        mock_get_addr.assert_called_with(self.request)
-
     @mock.patch('mycity.mycity_controller.get_trash_day_info')
     def test_intent_that_needs_address_with_address_in_session_attributes(
             self,

--- a/mycity/platforms/amazon/models/en_US.json
+++ b/mycity/platforms/amazon/models/en_US.json
@@ -4,25 +4,6 @@
             "invocationName": "boston info",
             "intents": [
                 {
-                    "name": "SetAddressIntent",
-                    "slots": [
-                        {
-                            "name": "Address",
-                            "type": "AMAZON.PostalAddress"
-                        }
-                    ],
-                    "samples": [
-                        "my address is {Address}",
-                        "i live at {Address}",
-                        "my home address is {Address}",
-                        "set address {Address}",
-                        "set my address to {Address}",
-                        "change address to {Address}",
-                        "update address to {Address}",
-                        "new address is {Address}"
-                    ]
-                },
-                {
                     "name": "TrashDayIntent",
                     "slots": [
                         {


### PR DESCRIPTION
Removes SetAddressIntent. This is not useful as a base intent. We should instead be asking for information from the user through a dialog interaction, like we do currently with trash day and other location based intents. 

Closes #233 

