### PR TITLE
Add exception handling for bad URL schemes in feedback intent

### DIFF
--- a/mycity/mycity/intents/feedback_intent.py
+++ b/mycity/mycity/intents/feedback_intent.py
@@ -55,7 +55,7 @@ def submit_feedback(mycity_request):
                 mycity_response.output_speech = speech_constants.BIG_THANKS
             else:
                 mycity_response.output_speech = speech_constants.PROBLEM_SAVING_FEEDBACK
-        except requests.exceptions.MissingSchema:
+        except Exception:
             mycity_response.output_speech = speech_constants.PROBLEM_SAVING_FEEDBACK
 
         mycity_response.reprompt_text = None

--- a/mycity/mycity/intents/feedback_intent.py
+++ b/mycity/mycity/intents/feedback_intent.py
@@ -46,13 +46,18 @@ def submit_feedback(mycity_request):
     else:
         feedback_type = intent_variables['FeedbackType']['value']
         feedback_text = intent_variables['Feedback']['value']
-        status = send_to_slack(
-            build_slack_message(feedback_type, feedback_text)
-        )
-        if status == 200:
-            mycity_response.output_speech = speech_constants.BIG_THANKS
-        else:
+
+        try:
+            status = send_to_slack(
+                build_slack_message(feedback_type, feedback_text)
+            )
+            if status == 200:
+                mycity_response.output_speech = speech_constants.BIG_THANKS
+            else:
+                mycity_response.output_speech = speech_constants.PROBLEM_SAVING_FEEDBACK
+        except requests.exceptions.MissingSchema:
             mycity_response.output_speech = speech_constants.PROBLEM_SAVING_FEEDBACK
+
         mycity_response.reprompt_text = None
         mycity_response.session_attributes = mycity_request.session_attributes
         mycity_response.card_title = CARD_TITLE

--- a/mycity/mycity/intents/speech_constants/feedback_intent.py
+++ b/mycity/mycity/intents/speech_constants/feedback_intent.py
@@ -4,4 +4,4 @@ Speech constants for feedback_intent.py
 """
 
 BIG_THANKS = "Thanks for your feedback."
-PROBLEM_SAVING_FEEDBACK = "There was a problem with your feedback. Please try again."
+PROBLEM_SAVING_FEEDBACK = "There was a problem with your feedback. Please try again later."


### PR DESCRIPTION
Addresses #238 

I haven't been able to reproduce the exact issue reported, but can get some errors with bad Slack webhook URLs. This puts in some protections around our request calls and returns reasonable speech on errors instead of the lambda function erroring out. 