### PR TITLE
Add some sample utterances containing the user's neighborhood

### DIFF
--- a/mycity/platforms/amazon/models/en_US.json
+++ b/mycity/platforms/amazon/models/en_US.json
@@ -10,6 +10,9 @@
                             "name": "Address",
                             "type": "AMAZON.PostalAddress",
                             "samples": [
+                                "{Address} {Neighborhood}",
+                                "It's {Address} in {Neighborhood}",
+                                "{Address} in {Neighborhood}",
                                 "It's {Address}",
                                 "My address is {Address}",
                                 "{Address}"
@@ -1294,6 +1297,13 @@
                         {
                             "name": "Zipcode",
                             "type": "AMAZON.NUMBER",
+                            "confirmationRequired": false,
+                            "elicitationRequired": false,
+                            "prompts": {}
+                        },
+                        {
+                            "name": "Neighborhood",
+                            "type": "AMAZON.City",
                             "confirmationRequired": false,
                             "elicitationRequired": false,
                             "prompts": {}


### PR DESCRIPTION
When we ask for the user's address, they may also include the neighborhood (ex "123 Fake Street in Roxbury"). Adding these utterance will help catch these and reduce the back and forth between the user and Alexa