### PR TITLE
Handle the NavigateHomeIntent

### DIFF
--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -152,7 +152,8 @@ def on_intent(mycity_request):
     elif mycity_request.intent_name == "AMAZON.HelpIntent":
         return get_help_response(mycity_request)
     elif mycity_request.intent_name == "AMAZON.StopIntent" or \
-            mycity_request.intent_name == "AMAZON.CancelIntent":
+            mycity_request.intent_name == "AMAZON.CancelIntent" or \
+                mycity_request.intent_name == "AMAZON.NavigateHomeIntent":
         return handle_session_end_request(mycity_request)
     elif mycity_request.intent_name == "FeedbackIntent":
         return submit_feedback(mycity_request)


### PR DESCRIPTION
Closes #261 

In this case, it wasn't a saved location that was causing a problem. Instead, we were missing the "AMAZON.NavigateHomeIntent" built in intent, which in our case should cause the skill to exit. 
