### PR TITLE
Fix trash day queries with 'N.' or 'S.' in the ReCollect database

### DIFF
--- a/mycity/mycity/intents/trash_intent.py
+++ b/mycity/mycity/intents/trash_intent.py
@@ -177,8 +177,8 @@ def validate_found_address(found_address, user_provided_address):
         return False
 
     # Re-collect replaces South with S and North with N
-    found_address["street_name"] = re.sub(r'^S\.? ', "South", found_address["street_name"])
-    found_address["street_name"] = re.sub(r'^N\.? ', "North", found_address["street_name"])
+    found_address["street_name"] = re.sub(r'^S\.? ', "South ", found_address["street_name"])
+    found_address["street_name"] = re.sub(r'^N\.? ', "North ", found_address["street_name"])
 
     if found_address["street_name"].lower() != \
             user_provided_address["street_name"].lower():


### PR DESCRIPTION
Since the regex looks for a space after 'N' or 'S', we need to keep the space when substituting and comparing to the user provided address.

Repro steps can be found in #263 

Closes #263 