### PR TITLE
271 add geolocation to foodtrucks

### DIFF
--- a/mycity/lambda_function.py
+++ b/mycity/lambda_function.py
@@ -150,7 +150,7 @@ def mycity_response_to_platform(mycity_response):
                     'text': mycity_response.output_speech
              },
                 'card': {
-                    'type': 'Simple',
+                    'type': mycity_response.card_type,
                     'title': str(mycity_response.card_title),
                     'content': str(mycity_response.output_speech)
                 },
@@ -172,7 +172,7 @@ def mycity_response_to_platform(mycity_response):
                 'text': mycity_response.output_speech
             },
             'card': {
-                'type': 'Simple',
+                'type': str(mycity_response.card_type),
                 'title': str(mycity_response.card_title),
                 'content': str(mycity_response.output_speech)
             },
@@ -184,6 +184,9 @@ def mycity_response_to_platform(mycity_response):
             },
             'shouldEndSession': mycity_response.should_end_session
         }
+
+    if mycity_response.card_permissions:
+        response['card']['permissions'] = mycity_response.card_permissions
 
     if mycity_response.dialog_directive == "Dialog.ElicitSlot":
         # Add the slot we want to elicit on top of the normal output.

--- a/mycity/lambda_function.py
+++ b/mycity/lambda_function.py
@@ -59,6 +59,10 @@ def _get_location_services_info(event: object, mycity_request: object) -> object
     if (mycity_request.device_has_geolocation):
         mycity_request.geolocation_permission = "Geolocation" in event["context"]
 
+    # Get coordinates
+    if (mycity_request.geolocation_permission):
+        mycity_request.geolocation_coordinates = event["context"]["Geolocation"].get("coordinate", {})
+
     return mycity_request
 
 def platform_to_mycity_request(event):

--- a/mycity/lambda_function.py
+++ b/mycity/lambda_function.py
@@ -42,7 +42,7 @@ def lambda_handler(event, context):
 
 def _get_location_services_info(event: object, mycity_request: object) -> object:
     """
-    Converts Alexa location services to MyCityRequestDataModel
+    Adds Alexa location services to MyCityRequestDataModel
 
     :param event: event JSON object provided by Alexa
     :param mycity_request: MyCityRequestDataModel to add location service info to
@@ -150,7 +150,7 @@ def mycity_response_to_platform(mycity_response):
                     'text': mycity_response.output_speech
              },
                 'card': {
-                    'type': mycity_response.card_type,
+                    'type': str(mycity_response.card_type),
                     'title': str(mycity_response.card_title),
                     'content': str(mycity_response.output_speech)
                 },

--- a/mycity/lambda_function.py
+++ b/mycity/lambda_function.py
@@ -52,20 +52,31 @@ def platform_to_mycity_request(event):
     """
     logger.debug('Amazon request received: ' + str(event))
     mycity_request = MyCityRequestDataModel()
+
+    # Get base request information
     mycity_request.request_type = event['request']['type']
     mycity_request.request_id = event['request']['requestId']
+
+    # Get session information
     mycity_request.is_new_session = event['session']['new']
     mycity_request.session_id = event['session']['sessionId']
+    mycity_request.application_id = event['session']['application']['applicationId']
 
+    # Get device information
     system_context = event['context']['System']
-    mycity_request.device_id = system_context.get('device', {}).get('deviceId', "unknown")
+    device_context = system_context.get('device', {})
+    mycity_request.device_id = device_context.get('deviceId', "unknown")
     mycity_request.api_access_token = system_context.get('apiAccessToken', "none")
+
+    # Determine location services support
+    supported_interfaces = device_context.get("supportedInterfaces", {})
+    mycity_request.device_has_geolocation = "Geolocation" in supported_interfaces
 
     if 'attributes' in event['session']:
         mycity_request.session_attributes = event['session']['attributes']
     else:
         mycity_request.session_attributes = {}
-    mycity_request.application_id = event['session']['application']['applicationId']
+    
     if 'intent' in event['request']:
         mycity_request.intent_name = event['request']['intent']['name']
         if 'slots' in event['request']['intent']:

--- a/mycity/mycity/deploy_tools/deploy_tools.py
+++ b/mycity/mycity/deploy_tools/deploy_tools.py
@@ -17,7 +17,7 @@ import json
 # path constants
 PROJECT_ROOT = os.path.join(os.getcwd(), os.path.pardir, os.path.pardir)
 TEMP_DIR_PATH = os.path.join(PROJECT_ROOT, 'temp')
-LAMBDA_REL_PATH = 'platforms/amazon/lambda/custom/lambda_function.py'
+LAMBDA_REL_PATH = 'lambda_function.py'
 LAMBDA_FUNCTION_PATH = os.path.join(PROJECT_ROOT, LAMBDA_REL_PATH)
 INTERACTION_MODEL_REL_PATH = 'platforms/amazon/models/en_US.json'
 INTERACTION_MODEL_PATH = os.path.join(PROJECT_ROOT, INTERACTION_MODEL_REL_PATH)

--- a/mycity/mycity/intents/food_truck_intent.py
+++ b/mycity/mycity/intents/food_truck_intent.py
@@ -7,7 +7,9 @@ import mycity.intents.speech_constants.food_truck_intent as speech_constants
 import logging
 from mycity.intents.intent_constants import CURRENT_ADDRESS_KEY
 from mycity.intents.user_address_intent import clear_address_from_mycity_object
+from mycity.intents.user_address_intent import request_user_address_response
 from mycity.mycity_response_data_model import MyCityResponseDataModel
+import mycity.utilities.location_services_utils as location_services_utils
 from streetaddress import StreetAddressParser
 from .custom_errors import \
     InvalidAddressError, BadAPIResponse, MultipleAddressError
@@ -63,6 +65,28 @@ def get_truck_locations(given_address):
             truck_unique_locations.append(t)
     return truck_unique_locations
 
+def _get_address_from_session(mycity_request):
+    usr_addr = None
+    if CURRENT_ADDRESS_KEY in mycity_request.session_attributes:
+        # Fall back to user address in session
+        current_address = \
+            mycity_request.session_attributes[CURRENT_ADDRESS_KEY]
+        address_parser = StreetAddressParser()
+        a = address_parser.parse(current_address)
+        address = str(a["house"]) + " " + str(a["street_name"]) + " " \
+                + str(a["street_type"])
+        usr_addr = gis_utils.geocode_address(address)
+
+    return usr_addr
+
+
+def _get_address_from_geolocation(mycity_request):
+    usr_addr = None
+    if mycity_request.device_has_geolocation:
+        if mycity_request.geolocation_permission:
+            usr_addr = location_services_utils.convert_mycity_coordinates_to_arcgis(mycity_request)
+    return usr_addr
+
 
 def get_nearby_food_trucks(mycity_request):
     """
@@ -73,82 +97,72 @@ def get_nearby_food_trucks(mycity_request):
     """
     mycity_response = MyCityResponseDataModel()
 
-    # Get current address location
-    if CURRENT_ADDRESS_KEY in mycity_request.session_attributes:
-        current_address = \
-            mycity_request.session_attributes[CURRENT_ADDRESS_KEY]
+    # See if the user provided a custom address
+    usr_addr = _get_address_from_session(mycity_request)
 
-        # Parsing street address using street-address package
-        address_parser = StreetAddressParser()
-        a = address_parser.parse(current_address)
-        address = str(a["house"]) + " " + str(a["street_name"]) + " " \
-                  + str(a["street_type"])
+    # If not, try to get user position from geolocation
+    if not usr_addr:
+        usr_addr = _get_address_from_geolocation(mycity_request)
 
-        # Parsing zip code
-        zip_code = str(a["other"]).zfill(5) if a["other"] else None
-        zip_code_key = intent_constants.ZIP_CODE_KEY
-        if zip_code is None and zip_code_key in \
-                mycity_request.session_attributes:
-            zip_code = mycity_request.session_attributes[zip_code_key]
+    if not usr_addr:
+        # Couldn't get address. Request the to use geolocation if possible, fall back to 
+        # asking for speech input
+        if mycity_request.device_has_geolocation:
+            return location_services_utils.request_geolocation_permission_response()
+        else:
+            return request_user_address_response(mycity_request)
 
-        # Get user's GIS Geocode Address and list of available trucks
-        usr_addr = gis_utils.geocode_address(address)
-        truck_unique_locations = get_truck_locations(usr_addr)
+    # Get list of available trucks
+    truck_unique_locations = get_truck_locations(usr_addr)
 
-        # Create custom response based on number of trucks returned
-        try:
-            if len(truck_unique_locations) == 0:
-                mycity_response.output_speech = "I didn't find any food trucks!"
+    # Create custom response based on number of trucks returned
+    try:
+        if len(truck_unique_locations) == 0:
+            mycity_response.output_speech = "I didn't find any food trucks near you!"
 
-            if len(truck_unique_locations) == 1:
-                response = f"I found {len(truck_unique_locations)} food " \
-                           f"truck within a mile from your address! "
-                response += add_response_text(truck_unique_locations)
-                mycity_response.output_speech = response
+        if len(truck_unique_locations) == 1:
+            response = f"I found {len(truck_unique_locations)} food " \
+                        f"truck within a mile from your address! "
+            response += add_response_text(truck_unique_locations)
+            mycity_response.output_speech = response
 
-            if 1 < len(truck_unique_locations) <= 3:
-                response = f"I found {len(truck_unique_locations)} food " \
-                           f"trucks within a mile from your address! "
-                response += add_response_text(truck_unique_locations)
-                mycity_response.output_speech = response
+        if 1 < len(truck_unique_locations) <= 3:
+            response = f"I found {len(truck_unique_locations)} food " \
+                        f"trucks within a mile from your address! "
+            response += add_response_text(truck_unique_locations)
+            mycity_response.output_speech = response
 
-            if len(truck_unique_locations) > 3:
-                response = f"There are at least {len(truck_unique_locations)}" \
-                           f" food trucks within a mile from your " \
-                           f"address! Here are the first five. "
-                response += add_response_text(truck_unique_locations)
-                mycity_response.output_speech = response
+        if len(truck_unique_locations) > 3:
+            response = f"There are at least {len(truck_unique_locations)}" \
+                        f" food trucks within a mile from your " \
+                        f"address! Here are the first five. "
+            response += add_response_text(truck_unique_locations)
+            mycity_response.output_speech = response
 
-        except InvalidAddressError:
-            address_string = address
-            if zip_code:
-                address_string = address_string + " with zip code {}"\
-                    .format(zip_code)
-            mycity_response.output_speech = \
-                speech_constants.ADDRESS_NOT_FOUND.format(address_string)
-            mycity_response.dialog_directive = "ElicitSlotFoodTruck"
-            mycity_response.reprompt_text = None
-            mycity_response.session_attributes = \
-                mycity_request.session_attributes
-            mycity_response.card_title = CARD_TITLE
-            mycity_request = clear_address_from_mycity_object(mycity_request)
-            mycity_response = clear_address_from_mycity_object(mycity_response)
-            mycity_response.should_end_session = True
-            return mycity_response
+    except InvalidAddressError:
+        address_string = address
+        mycity_response.output_speech = \
+            speech_constants.ADDRESS_NOT_FOUND.format(address_string)
+        mycity_response.dialog_directive = "ElicitSlotFoodTruck"
+        mycity_response.reprompt_text = None
+        mycity_response.session_attributes = \
+            mycity_request.session_attributes
+        mycity_response.card_title = CARD_TITLE
+        mycity_request = clear_address_from_mycity_object(mycity_request)
+        mycity_response = clear_address_from_mycity_object(mycity_response)
+        mycity_response.should_end_session = True
+        return mycity_response
 
-        except BadAPIResponse:
-            mycity_response.output_speech = \
-                "Hmm something went wrong. Maybe try again?"
+    except BadAPIResponse:
+        mycity_response.output_speech = \
+            "Hmm something went wrong. Maybe try again?"
 
-        except MultipleAddressError:
-            mycity_response.output_speech = \
-                speech_constants.MULTIPLE_ADDRESS_ERROR.format(address)
-            mycity_response.dialog_directive = "ElicitSlotZipCode"
+    except MultipleAddressError:
+        mycity_response.output_speech = \
+            speech_constants.MULTIPLE_ADDRESS_ERROR.format(address)
+        mycity_response.dialog_directive = "ElicitSlotZipCode"
 
-    else:
-        logger.error("Error: Called food_truck_intent with no address")
-        mycity_response.output_speech = "I didn't understand that address, " \
-                                        "please try again"
+
 
     # Setting reprompt_text to None signifies that we do not want to reprompt
     # the user. If the user does not respond or says something that is not

--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -143,10 +143,7 @@ def on_intent(mycity_request):
             not in mycity_request.session_attributes \
             else get_crime_incidents_intent(mycity_request)
     elif mycity_request.intent_name == "FoodTruckIntent":
-        return request_user_address_response(mycity_request) \
-            if intent_constants.CURRENT_ADDRESS_KEY \
-            not in mycity_request.session_attributes \
-            else get_nearby_food_trucks(mycity_request)
+        return get_nearby_food_trucks(mycity_request)
     elif mycity_request.intent_name == "GetAlertsIntent":
         return get_alerts_intent(mycity_request)
     elif mycity_request.intent_name == "AMAZON.HelpIntent":

--- a/mycity/mycity/mycity_request_data_model.py
+++ b/mycity/mycity/mycity_request_data_model.py
@@ -28,6 +28,7 @@ class MyCityRequestDataModel:
         self._intent_variables = {}
         self._device_id = None
         self._api_access_token = None
+        self._has_geolocation = None
 
     def __str__(self):
         return """\
@@ -41,7 +42,8 @@ class MyCityRequestDataModel:
             intent_name={},
             intent_variables={},
             device_id={},
-            api_access_token={}
+            api_access_token={},
+            has_geolocation={}
         >
         """.format(
             self._request_type,
@@ -53,7 +55,8 @@ class MyCityRequestDataModel:
             self._intent_name,
             self._intent_variables,
             self._device_id,
-            self._api_access_token
+            self._api_access_token,
+            self._has_geolocation
         )
 
     def get_logger_string(self):
@@ -164,3 +167,15 @@ class MyCityRequestDataModel:
     @api_access_token.setter
     def api_access_token(self, value):
         self._api_access_token = value
+
+    @property
+    def device_has_geolocation(self):
+        """
+        Returns if the user's device has geolocation services
+        """
+        return self._has_geolocation
+
+    @device_has_geolocation.setter
+    def device_has_geolocation(self, value: bool):
+        self._has_geolocation = value
+    

--- a/mycity/mycity/mycity_request_data_model.py
+++ b/mycity/mycity/mycity_request_data_model.py
@@ -29,6 +29,7 @@ class MyCityRequestDataModel:
         self._device_id = None
         self._api_access_token = None
         self._has_geolocation = None
+        self._geolocation_permission = None
 
     def __str__(self):
         return """\
@@ -43,7 +44,8 @@ class MyCityRequestDataModel:
             intent_variables={},
             device_id={},
             api_access_token={},
-            has_geolocation={}
+            has_geolocation={},
+            _geolocation_permission={}
         >
         """.format(
             self._request_type,
@@ -56,7 +58,8 @@ class MyCityRequestDataModel:
             self._intent_variables,
             self._device_id,
             self._api_access_token,
-            self._has_geolocation
+            self._has_geolocation,
+            self._geolocation_permission
         )
 
     def get_logger_string(self):
@@ -178,4 +181,17 @@ class MyCityRequestDataModel:
     @device_has_geolocation.setter
     def device_has_geolocation(self, value: bool):
         self._has_geolocation = value
+    
+    @property
+    def geolocation_permission(self):
+        """
+        Returns if this device has geolocation permission
+        """
+        if not self._has_geolocation:
+            return False
+        return self._geolocation_permission
+
+    @geolocation_permission.setter
+    def geolocation_permission(self, value: bool):
+        self._geolocation_permission = value
     

--- a/mycity/mycity/mycity_request_data_model.py
+++ b/mycity/mycity/mycity_request_data_model.py
@@ -30,6 +30,7 @@ class MyCityRequestDataModel:
         self._api_access_token = None
         self._has_geolocation = None
         self._geolocation_permission = None
+        self._geolocation_coordinates = None
 
     def __str__(self):
         return """\
@@ -45,7 +46,8 @@ class MyCityRequestDataModel:
             device_id={},
             api_access_token={},
             has_geolocation={},
-            _geolocation_permission={}
+            geolocation_permission={},
+            geolocation_coordinates={}
         >
         """.format(
             self._request_type,
@@ -59,7 +61,8 @@ class MyCityRequestDataModel:
             self._device_id,
             self._api_access_token,
             self._has_geolocation,
-            self._geolocation_permission
+            self._geolocation_permission,
+            self._geolocation_coordinates
         )
 
     def get_logger_string(self):
@@ -194,4 +197,12 @@ class MyCityRequestDataModel:
     @geolocation_permission.setter
     def geolocation_permission(self, value: bool):
         self._geolocation_permission = value
+
+    @property
+    def geolocation_coordinates(self):
+        return self._geolocation_coordinates
+
+    @geolocation_coordinates.setter
+    def geolocation_coordinates(self, value: dict):
+        self._geolocation_coordinates = value
     

--- a/mycity/mycity/mycity_request_data_model.py
+++ b/mycity/mycity/mycity_request_data_model.py
@@ -204,5 +204,8 @@ class MyCityRequestDataModel:
 
     @geolocation_coordinates.setter
     def geolocation_coordinates(self, value: dict):
+        if "longitudeInDegrees" not in value or "latitudeInDegrees" not in value:
+            raise Exception("Missing dictionary value set on geolocation_coordinates")
+
         self._geolocation_coordinates = value
     

--- a/mycity/mycity/mycity_request_data_model.py
+++ b/mycity/mycity/mycity_request_data_model.py
@@ -177,7 +177,7 @@ class MyCityRequestDataModel:
     @property
     def device_has_geolocation(self):
         """
-        Returns if the user's device has geolocation services
+        Returns if the user's device supports geolocation services
         """
         return self._has_geolocation
 
@@ -188,7 +188,7 @@ class MyCityRequestDataModel:
     @property
     def geolocation_permission(self):
         """
-        Returns if this device has geolocation permission
+        Returns if our app has been granted geolocation permission
         """
         if not self._has_geolocation:
             return False
@@ -200,12 +200,15 @@ class MyCityRequestDataModel:
 
     @property
     def geolocation_coordinates(self):
+        """
+        Returns dictionary of geolocation coordinates.
+        """
         return self._geolocation_coordinates
 
     @geolocation_coordinates.setter
     def geolocation_coordinates(self, value: dict):
         if "longitudeInDegrees" not in value or "latitudeInDegrees" not in value:
-            raise Exception("Missing dictionary value set on geolocation_coordinates")
+            raise Exception("Missing expected dictionary key set on geolocation_coordinates")
 
         self._geolocation_coordinates = value
     

--- a/mycity/mycity/mycity_response_data_model.py
+++ b/mycity/mycity/mycity_response_data_model.py
@@ -2,6 +2,7 @@
 Data Model for structuring responses from the skill implementation
 """
 import logging
+from typing import List
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,8 @@ class MyCityResponseDataModel:
     def __init__(self):
         self._session_attributes = {}
         self._card_title = None
+        self._card_type = None
+        self._card_permissions = None
         self._output_speech = None
         self._reprompt_text = None
         self._should_end_session = None
@@ -34,16 +37,20 @@ class MyCityResponseDataModel:
         <MyCityResponseDataModel
             session_attributes={},
             card_title={},
+            card_type={},
+            card_permissions={},
             output_speech={},
             reprompt_text={},
             should_end_session={},
-            intent_variables={}
-            dialog_directive={}
-            slot_to_elicit={}
+            intent_variables={},
+            dialog_directive={},
+            slot_to_elicit={},
         >
         """.format(
             self._session_attributes,
             self._card_title,
+            self._card_type,
+            self._card_permissions,
             self._output_speech,
             self._reprompt_text,
             self._should_end_session,
@@ -170,3 +177,19 @@ class MyCityResponseDataModel:
                 'type': 'Dialog.ElicitSlot',
                 'slotToElicit': 'Neighborhood'
             }            
+
+    @property
+    def card_type(self):
+        return self._card_type
+
+    @card_type.setter
+    def card_type(self, value: str):
+        self._card_type = value
+
+    @property
+    def card_permissions(self):
+        return self._card_permissions
+
+    @card_permissions.setter
+    def card_permissions(self, value: List[str]):
+        self._card_permissions = value

--- a/mycity/mycity/mycity_response_data_model.py
+++ b/mycity/mycity/mycity_response_data_model.py
@@ -23,7 +23,7 @@ class MyCityResponseDataModel:
     def __init__(self):
         self._session_attributes = {}
         self._card_title = None
-        self._card_type = None
+        self._card_type = "Simple"
         self._card_permissions = None
         self._output_speech = None
         self._reprompt_text = None

--- a/mycity/mycity/test/integration_tests/test_food_truck_intent.py
+++ b/mycity/mycity/test/integration_tests/test_food_truck_intent.py
@@ -40,7 +40,7 @@ class FoodTruckTestCase(mix_ins.RepromptTextTestMixIn,
         self.get_address_api_patch.stop()
         self.get_truck_locations_patch.stop()
 
-    def test_delegates_if_not_provided_no_geolocation(self):
+    def test_delegates_if_address_not_provided_no_geolocation_support(self):
         self.request._session_attributes.pop(intent_constants.CURRENT_ADDRESS_KEY, None)
         response = self.controller.on_intent(self.request)
         self.assertEqual(response.dialog_directive['type'], "Dialog.Delegate")

--- a/mycity/mycity/test/test_data/base_alexa_request.json
+++ b/mycity/mycity/test/test_data/base_alexa_request.json
@@ -19,7 +19,7 @@
 		}
 	},
 	"request": {
-		"type": "BaseTestRequst",
+		"type": "BaseTestRequest",
 		"requestId": "TestDataRequestID",
 		"timestamp": "2019-08-04T13:41:19Z",
 		"locale": "en-US",

--- a/mycity/mycity/test/test_data/base_alexa_request.json
+++ b/mycity/mycity/test/test_data/base_alexa_request.json
@@ -1,0 +1,28 @@
+{
+	"version": "1.0",
+	"session": {
+		"new": true,
+		"sessionId": "fake-session-id",
+		"application": {
+			"applicationId": "fake-application-id"
+		},
+		"user": {
+			"userId": "fake-user-id"
+		}
+	},
+	"context": {
+		"System": {
+			"application": {
+				"applicationId": "fake-context-application-id"
+			},
+			"apiEndpoint": "https://api.amazonalexa.com"
+		}
+	},
+	"request": {
+		"type": "BaseTestRequst",
+		"requestId": "TestDataRequestID",
+		"timestamp": "2019-08-04T13:41:19Z",
+		"locale": "en-US",
+		"shouldLinkResultBeReturned": false
+	}
+}

--- a/mycity/mycity/test/unit_tests/test_lambda_function.py
+++ b/mycity/mycity/test/unit_tests/test_lambda_function.py
@@ -1,0 +1,34 @@
+""" Tests for functions specific to Alexa devices """
+
+import lambda_function as lambda_function
+
+import json
+import unittest
+
+class TestAlexaLambdaFunction(unittest.TestCase):
+
+    def setUp(self):
+        try:
+            with open('mycity/test/test_data/base_alexa_request.json') as fh:
+                self.alexa_request_json = json.load(fh)
+
+        except Exception:
+            print("Failed to read base Alexa request test data\n")
+            pass
+
+    def test_correct_mycity_conversion_for_no_geolocation_support(self):
+        mycity_request = lambda_function.platform_to_mycity_request(self.alexa_request_json)
+        self.assertFalse(mycity_request.device_has_geolocation)
+
+    def test_correct_mycity_conversion_for_geolocation_support(self):
+        self.alexa_request_json["context"]["System"]["device"] = {
+            "supportedInterfaces" : {
+                "Geolocation": {}
+            }
+        }
+        mycity_request = lambda_function.platform_to_mycity_request(self.alexa_request_json)
+        self.assertTrue(mycity_request.device_has_geolocation)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mycity/mycity/test/unit_tests/test_lambda_function.py
+++ b/mycity/mycity/test/unit_tests/test_lambda_function.py
@@ -5,7 +5,7 @@ import lambda_function as lambda_function
 import json
 import unittest
 
-class TestAlexaLambdaFunction(unittest.TestCase):
+class TestAlexaLambdaFunctionLocationServices(unittest.TestCase):
 
     def setUp(self):
         try:
@@ -16,18 +16,45 @@ class TestAlexaLambdaFunction(unittest.TestCase):
             print("Failed to read base Alexa request test data\n")
             pass
 
-    def test_correct_mycity_conversion_for_no_geolocation_support(self):
-        mycity_request = lambda_function.platform_to_mycity_request(self.alexa_request_json)
-        self.assertFalse(mycity_request.device_has_geolocation)
-
-    def test_correct_mycity_conversion_for_geolocation_support(self):
+    def _add_geolocation_support_to_json(self):
         self.alexa_request_json["context"]["System"]["device"] = {
             "supportedInterfaces" : {
                 "Geolocation": {}
             }
         }
+
+    def _add_geolocation_info_to_json(self):
+        self.alexa_request_json["context"]["Geolocation"] = {
+             "coordinate": {
+                "latitudeInDegrees": 38.2,
+                "longitudeInDegrees": 28.3,
+                "accuracyInMeters": 12.1 
+            }
+        }
+
+    def test_correct_mycity_conversion_for_no_geolocation_support(self):
+        mycity_request = lambda_function.platform_to_mycity_request(self.alexa_request_json)
+        self.assertFalse(mycity_request.device_has_geolocation)
+
+    def test_correct_mycity_conversion_for_geolocation_support(self):
+        self._add_geolocation_support_to_json()
         mycity_request = lambda_function.platform_to_mycity_request(self.alexa_request_json)
         self.assertTrue(mycity_request.device_has_geolocation)
+
+    def test_geolcation_no_oermission_on_unsupported_device(self):
+        mycity_request = lambda_function.platform_to_mycity_request(self.alexa_request_json)
+        self.assertFalse(mycity_request.geolocation_permission)
+
+    def test_geolocation_no_permission_on_supported_device(self):
+        self._add_geolocation_support_to_json()
+        mycity_request = lambda_function.platform_to_mycity_request(self.alexa_request_json)
+        self.assertFalse(mycity_request.geolocation_permission)
+
+    def test_geolocation_permission_when_info_is_present(self):
+        self._add_geolocation_support_to_json()
+        self._add_geolocation_info_to_json()
+        mycity_request = lambda_function.platform_to_mycity_request(self.alexa_request_json)
+        self.assertTrue(mycity_request.geolocation_permission)
 
 
 if __name__ == '__main__':

--- a/mycity/mycity/test/unit_tests/test_lambda_function.py
+++ b/mycity/mycity/test/unit_tests/test_lambda_function.py
@@ -56,6 +56,13 @@ class TestAlexaLambdaFunctionLocationServices(unittest.TestCase):
         mycity_request = lambda_function.platform_to_mycity_request(self.alexa_request_json)
         self.assertTrue(mycity_request.geolocation_permission)
 
+    def test_geolocation_permission_has_coordinates(self):
+        self._add_geolocation_support_to_json()
+        self._add_geolocation_info_to_json()
+        mycity_request = lambda_function.platform_to_mycity_request(self.alexa_request_json)
+        self.assertTrue("latitudeInDegrees" in mycity_request.geolocation_coordinates)
+        self.assertTrue("longitudeInDegrees" in mycity_request.geolocation_coordinates)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mycity/mycity/test/unit_tests/test_lambda_function.py
+++ b/mycity/mycity/test/unit_tests/test_lambda_function.py
@@ -41,7 +41,7 @@ class TestAlexaLambdaFunctionLocationServices(unittest.TestCase):
         mycity_request = lambda_function.platform_to_mycity_request(self.alexa_request_json)
         self.assertTrue(mycity_request.device_has_geolocation)
 
-    def test_geolcation_no_oermission_on_unsupported_device(self):
+    def test_geolcation_no_permission_on_unsupported_device(self):
         mycity_request = lambda_function.platform_to_mycity_request(self.alexa_request_json)
         self.assertFalse(mycity_request.geolocation_permission)
 

--- a/mycity/mycity/test/unit_tests/test_location_services_utils.py
+++ b/mycity/mycity/test/unit_tests/test_location_services_utils.py
@@ -1,3 +1,4 @@
+""" Tests utilities for location services  """
 
 import mycity.test.unit_tests.base as base
 import mycity.utilities.location_services_utils as location_services_utils

--- a/mycity/mycity/test/unit_tests/test_location_services_utils.py
+++ b/mycity/mycity/test/unit_tests/test_location_services_utils.py
@@ -1,0 +1,18 @@
+
+import mycity.test.unit_tests.base as base
+import mycity.utilities.location_services_utils as location_services_utils
+
+import unittest
+
+class LocationServicesUtilsUnitTestCase(base.BaseTestCase):
+
+    def test_request_geolocation_permissions_card_type(self):
+        response = location_services_utils.request_geolocation_permission_response()
+        self.assertEqual(response.card_type, "AskForPermissionsConsent")
+
+    def test_request_geolocation_permissions_card_permissions(self):
+        response = location_services_utils.request_geolocation_permission_response()
+        self.assertTrue(any("geolocation:read" in permission for permission in response.card_permissions))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mycity/mycity/utilities/location_services_utils.py
+++ b/mycity/mycity/utilities/location_services_utils.py
@@ -1,4 +1,4 @@
-""" Methods for determining location base permissions and extracting the location data """
+"""Methods for determining location base permissions and extracting the location data"""
 
 import mycity.mycity_response_data_model as mycity_response_data_model
 

--- a/mycity/mycity/utilities/location_services_utils.py
+++ b/mycity/mycity/utilities/location_services_utils.py
@@ -1,0 +1,22 @@
+""" Methods for determining location base permissions and extracting the location data """
+
+import mycity.mycity_response_data_model as mycity_response_data_model
+
+GENERIC_GEOLOCATION_PRERMISSON_SPEECH = """
+    Boston Info would like to use your location. 
+    To turn on location sharing, please go to your Alexa app, 
+    and follow the instructions."""
+
+def request_geolocation_permission_response():
+    """
+    Builds a response object for requesting geolocation permissions. The
+    returned object's speech can be modified if you want to add more information
+
+    :return MyCityResponseDataModel: MyCityResponseDataModel with required fields
+        to request geolocation access
+    """
+    response = mycity_response_data_model.MyCityResponseDataModel()
+    response.output_speech = GENERIC_GEOLOCATION_PRERMISSON_SPEECH
+    response.card_type = "AskForPermissionsConsent"
+    response.card_permissions = ["alexa::devices:all:geolocation:read"]
+    return response

--- a/mycity/mycity/utilities/location_services_utils.py
+++ b/mycity/mycity/utilities/location_services_utils.py
@@ -4,8 +4,7 @@ import mycity.mycity_response_data_model as mycity_response_data_model
 
 GENERIC_GEOLOCATION_PRERMISSON_SPEECH = """
     Boston Info would like to use your location. 
-    To turn on location sharing, please go to your Alexa app, 
-    and follow the instructions."""
+    To turn on location sharing, please go to your Alexa app and follow the instructions."""
 
 def request_geolocation_permission_response():
     """
@@ -19,4 +18,22 @@ def request_geolocation_permission_response():
     response.output_speech = GENERIC_GEOLOCATION_PRERMISSON_SPEECH
     response.card_type = "AskForPermissionsConsent"
     response.card_permissions = ["alexa::devices:all:geolocation:read"]
+    response.should_end_session = True
     return response
+
+
+def convert_mycity_coordinates_to_arcgis(mycity_request):
+    """
+    Gets coordinates from a MyCityRequestDataModel and converts them to dictionary
+    required by GIS utilities
+    """
+    gis_coordinates = {
+        'x': 0,
+        'y': 0
+    }
+    
+    if mycity_request.geolocation_coordinates:
+        gis_coordinates['y'] = mycity_request.geolocation_coordinates["latitudeInDegrees"]
+        gis_coordinates['x'] = mycity_request.geolocation_coordinates["longitudeInDegrees"]
+
+    return gis_coordinates

--- a/mycity/mycity/utilities/location_services_utils.py
+++ b/mycity/mycity/utilities/location_services_utils.py
@@ -1,4 +1,4 @@
-"""Methods for determining location base permissions and extracting the location data"""
+""" Methods for working with location based data """
 
 import mycity.mycity_response_data_model as mycity_response_data_model
 
@@ -9,7 +9,7 @@ GENERIC_GEOLOCATION_PRERMISSON_SPEECH = """
 def request_geolocation_permission_response():
     """
     Builds a response object for requesting geolocation permissions. The
-    returned object's speech can be modified if you want to add more information
+    returned object's speech can be modified if you want to add more information.
 
     :return MyCityResponseDataModel: MyCityResponseDataModel with required fields
         to request geolocation access
@@ -22,10 +22,14 @@ def request_geolocation_permission_response():
     return response
 
 
-def convert_mycity_coordinates_to_arcgis(mycity_request):
+def convert_mycity_coordinates_to_arcgis(mycity_request)->dict:
     """
     Gets coordinates from a MyCityRequestDataModel and converts them to dictionary
     required by GIS utilities
+
+    :param mycity_request: MyCityRequstDataModel containing geolcation coordinates
+        to convert
+    :return dictionary: x, y coordinates of device location
     """
     gis_coordinates = {
         'x': 0,

--- a/mycity/platforms/amazon/models/en_US.json
+++ b/mycity/platforms/amazon/models/en_US.json
@@ -1095,16 +1095,17 @@
                         }
                     ],
                     "samples": [
+                        "what are the food trucks near {Address}",
+                        "food trucks at {Address}",
+                        "food trucks near {Address}",
+                        "are there any food trucks around {Address}",
+                        "where are the food trucks near {Address}",
                         "where are the nearest food trucks",
                         "what are the nearest food trucks",
                         "is there any food truck around",
                         "is there any food truck around me",
-                        "is there any food truck around my office",
-                        "is there any food truck around my house",
                         "are there any food trucks around",
                         "are there any food trucks around me",
-                        "are there any food trucks around my office",
-                        "are there any food trucks around my house",
                         "what kind of food trucks are around me",
                         "what kind of food trucks are near me",
                         "what kind of food trucks are nearby",
@@ -1243,7 +1244,8 @@
                         "farmers markets"
                     ]
                 }
-            ]
+            ],
+            "types": []
         },
         "dialog": {
             "intents": [
@@ -1322,6 +1324,13 @@
                             "prompts": {
                                 "elicitation": "Elicit.Slot.1478934588421.914733191093"
                             }
+                        },
+                        {
+                            "name": "Zipcode",
+                            "type": "AMAZON.NUMBER",
+                            "confirmationRequired": false,
+                            "elicitationRequired": false,
+                            "prompts": {}
                         }
                     ]
                 },


### PR DESCRIPTION
Add geolocation support for FoodTruckIntent.

This pull request has a number of changes to support geolocation.
- Determines if the devices supports geolocation, has permission, and provides the current location. This is all added to the MyCityRequestDataModel. See changes in `lambda_function.py` and `mycity_request_data_model.py`.
- Adds ability to request geolocation permissions from the user. See new file `location_services_utils.py` for how to create this request and the changes to `mycity_response_data_model.py`. In particular, this requires returning a special card type with the appropriate permissions request, which will provide in app instructions. 
- Moves logic for determining location requirements for the `FoodTruckIntent` from `mycity_controller.py` into `food_truck_intent.py`. We now try to use a provided address then the geolocation if none provided. If neither is provided, we determine what we should request from the user (geolocation permissions or user provided address) based on device support. 
- Adds additional sample utterances for `FoodTruckIntent` for overriding a geolocation.

In addition to changes for geolocation, I moved the location of `lambda_function.py`:
`mycity/platforms/amazon/lambda/custom/lambda_function.py` → `mycity/lambda_function.py`

This allows the functions in `lambda_functions.py` to be unit tested and have working imports. See changes to `deploy_tools.py` and the addition of `test_lambda_function.py`. If anyone knows why we had this in the current folder structure, please let me know. Moving this file seems useful to add to our test suite and helped in the development of this feature.

Addresses #271 for food truck intent