### PR TITLE
Allow users to specify number of crime incidents

### DIFF
--- a/mycity/mycity/intents/crime_activity_intent.py
+++ b/mycity/mycity/intents/crime_activity_intent.py
@@ -12,6 +12,9 @@ CARD_TITLE_CRIME = "Crime Report"
 RESPONSE_TEXT_TEMPLATE = " {} an incident at {} occurred categorized as {}."
 ERROR_RESPONSE = "An error occurred requesting crime incidents for this address"
 NO_RESULT_RESPONSE = "We found no incidents in that area"
+REQUEST_NUMBER_CRIME_INCIDENTS_SLOT_NAME = 'number_incidents'
+MAX_NUMBER_OF_CRIME_INCIDENTS = 10
+DEFAULT_NUMBER_OF_CRIME_INCIDENTS = 3
 
 # Crime API response fields
 OFFENSE_FIELD = "OFFENSE_DESCRIPTION"
@@ -24,6 +27,21 @@ RECORDS_FIELD = "records"
 
 logger = logging.getLogger(__name__)
 
+def number_of_crime_incidents(mycity_request):
+    """
+    Returns number of reports from the request if available or a default value
+    :param mycity_request: MyCityRequestDataModel object
+    :return: Number of crime incidents to return from this intent
+    """
+    if REQUEST_NUMBER_CRIME_INCIDENTS_SLOT_NAME in \
+            mycity_request.intent_variables and \
+            "value" in mycity_request.intent_variables[
+                REQUEST_NUMBER_CRIME_INCIDENTS_SLOT_NAME]:
+        return min(
+            int(mycity_request.intent_variables[REQUEST_NUMBER_CRIME_INCIDENTS_SLOT_NAME]["value"]),
+            MAX_NUMBER_OF_CRIME_INCIDENTS)
+
+    return DEFAULT_NUMBER_OF_CRIME_INCIDENTS
 
 def get_crime_incidents_intent(mycity_request):
     """
@@ -39,7 +57,8 @@ def get_crime_incidents_intent(mycity_request):
             mycity_request.session_attributes:
         address = mycity_request. \
             session_attributes[intent_constants.CURRENT_ADDRESS_KEY]
-        response = get_crime_incident_response(address)
+        number_incidents = number_of_crime_incidents(mycity_request)
+        response = get_crime_incident_response(address, number_incidents)
         mycity_response.output_speech = \
             _build_text_from_response(response)
     else:

--- a/mycity/mycity/test/unit_tests/test_crime_incidents_api_utils.py
+++ b/mycity/mycity/test/unit_tests/test_crime_incidents_api_utils.py
@@ -17,7 +17,8 @@ class CrimeIncidentsAPIUtilitiesTestCase(base.BaseTestCase):
         mock_get.return_value = mock_resp
 
         test_address = "46 Everdean St Boston, MA"
-        result = get_crime_incident_response(test_address)
+        test_number_incidents = 4
+        result = get_crime_incident_response(test_address, test_number_incidents)
         self.assertEqual(
             True,
             result['success']

--- a/mycity/mycity/utilities/crime_incidents_api_utils.py
+++ b/mycity/mycity/utilities/crime_incidents_api_utils.py
@@ -8,7 +8,7 @@ from mycity.utilities.gis_utils import geocode_address
 import logging
 
 RESOURCEID = "12cb3883-56f5-47de-afa5-3b1cf61b257b"
-QUERY_LIMIT = 5
+QUERY_LIMIT = 3
 CRIME_INCIDENTS_SQL_URL = \
     "https://data.boston.gov/api/3/action/datastore_search_sql"
 

--- a/mycity/mycity/utilities/crime_incidents_api_utils.py
+++ b/mycity/mycity/utilities/crime_incidents_api_utils.py
@@ -8,22 +8,22 @@ from mycity.utilities.gis_utils import geocode_address
 import logging
 
 RESOURCEID = "12cb3883-56f5-47de-afa5-3b1cf61b257b"
-QUERY_LIMIT = 3
 CRIME_INCIDENTS_SQL_URL = \
     "https://data.boston.gov/api/3/action/datastore_search_sql"
 
 logger = logging.getLogger(__name__)
 
 
-def get_crime_incident_response(address):
+def get_crime_incident_response(address, number_incidents):
     """
     Executes and returns the crime incident request response
 
     :param address: address to query
+    :param number_incidents: number of incidents to query
     :return: the raw json response
 
     """
-    url_parameters = {"sql": _build_query_string(address)}
+    url_parameters = {"sql": _build_query_string(address, number_incidents)}
     logger.debug("Finding crime incidents information for {} using query {}"
         .format(address, url_parameters))
     with requests.Session() as session:
@@ -34,11 +34,12 @@ def get_crime_incident_response(address):
     return {}
 
 
-def _build_query_string(address):
+def _build_query_string(address, number_incidents):
     """
     Builds the SQL query given an address
 
     :param address: address to query
+    :param number_incidents: number of incidents to query
     :return: a SQL query string
 
     """
@@ -48,7 +49,7 @@ def _build_query_string(address):
         .format(RESOURCEID,
                 coordinates[0],
                 coordinates[1],
-                QUERY_LIMIT)
+                number_incidents)
 
 
 def _get_coordinates_for_address(address):

--- a/mycity/platforms/amazon/models/en_US.json
+++ b/mycity/platforms/amazon/models/en_US.json
@@ -1002,9 +1002,16 @@
                                 "It's {Address}",
                                 "{Address}"
                             ]
+                        },
+                        {
+                            "name": "number_incidents",
+                            "type": "AMAZON.NUMBER"
                         }
                     ],
                     "samples": [
+                        "most recent {number_incidents} crime activity",
+                        "top {number_incidents} incidents happened near me",
+                        "top {number_incidents} crime activity",
                         "what's the crime activity in my area",
                         "what is the crime activity in my area",
                         "what crime incidents occurred in my area",
@@ -1347,6 +1354,13 @@
                             "prompts": {
                                 "elicitation": "Elicit.Slot.621270469710.323849903546"
                             }
+                        },
+                        {
+                            "name": "number_incidents",
+                            "type": "AMAZON.NUMBER",
+                            "confirmationRequired": false,
+                            "elicitationRequired": false,
+                            "prompts": {}
                         }
                     ]
                 }

--- a/mycity/platforms/amazon/models/en_US.json
+++ b/mycity/platforms/amazon/models/en_US.json
@@ -1009,9 +1009,13 @@
                         }
                     ],
                     "samples": [
+                        "{number_incidents} crimes near me",
+                        "tell me {number_incidents} crimes",
+                        "{number_incidents} most recent incidents happened near me",
+                        "what {number_incidents} crimes were reported",
+                        "give me {number_incidents} crime reports",
+                        "what are the {number_incidents} most recent crime reports",
                         "most recent {number_incidents} crime activity",
-                        "top {number_incidents} incidents happened near me",
-                        "top {number_incidents} crime activity",
                         "what's the crime activity in my area",
                         "what is the crime activity in my area",
                         "what crime incidents occurred in my area",


### PR DESCRIPTION
This PR tries to fix issue #185 commits include
- add default number of crime incidents, which is 3
- add function to grab number of crime incidents from mycity_request
- add utterances to train alexa model to recognize number of incidents
- modify unittest to reflect the changes