### PR TITLE
271 add location services to snow parking

### DIFF
--- a/mycity/mycity/intents/snow_parking_intent.py
+++ b/mycity/mycity/intents/snow_parking_intent.py
@@ -44,22 +44,23 @@ def get_snow_emergency_parking_intent(mycity_request):
 
     mycity_response = MyCityResponseDataModel()
 
-    # If not provided, try to get the user address through geolocation and device address
     coordinates = None
     if intent_constants.CURRENT_ADDRESS_KEY not in mycity_request.session_attributes:
+        # If not provided, try to get the user address through geolocation and device address
+
         coordinates = address_utils.get_address_coordinates_from_geolocation(mycity_request)
 
         if not coordinates: 
             if mycity_request.device_has_geolocation:
                 return location_services_utils.request_geolocation_permission_response()
 
-            # Try getting device location
+            # Try getting registered device address
             mycity_request, location_permissions = location_services_utils.get_address_from_user_device(mycity_request)
             if not location_permissions:
                 return location_services_utils.request_device_address_permission_response()
 
     
-    # If don't have coordinates or an address by now, ask the user
+    # If we don't have coordinates or an address by now, and we have all required permissions, ask the user
     if not coordinates and intent_constants.CURRENT_ADDRESS_KEY not in mycity_request.session_attributes:
         return user_address_intent.request_user_address_response(mycity_request)
 

--- a/mycity/mycity/intents/snow_parking_intent.py
+++ b/mycity/mycity/intents/snow_parking_intent.py
@@ -1,10 +1,12 @@
 """Alexa intent used to find snow emergency parking"""
 
-
 import mycity.intents.intent_constants as intent_constants
 import mycity.intents.speech_constants.snow_parking_intent as constants
+import mycity.intents.user_address_intent as user_address_intent
 from mycity.intents.custom_errors import InvalidAddressError
 from mycity.utilities.finder.FinderCSV import FinderCSV
+import mycity.utilities.address_utils as address_utils
+import mycity.utilities.location_services_utils as location_services_utils
 from mycity.mycity_response_data_model import MyCityResponseDataModel
 import logging
 
@@ -41,20 +43,39 @@ def get_snow_emergency_parking_intent(mycity_request):
     logger.debug('MyCityRequestDataModel received:' + mycity_request.get_logger_string())
 
     mycity_response = MyCityResponseDataModel()
-    if intent_constants.CURRENT_ADDRESS_KEY in mycity_request.session_attributes:
-        try:
-            finder = FinderCSV(mycity_request, PARKING_INFO_URL, ADDRESS_KEY,
-                               constants.OUTPUT_SPEECH_FORMAT, format_record_fields)
-        except InvalidAddressError:
-            mycity_response.output_speech = constants.ERROR_INVALID_ADDRESS
-        else:
-            print("Finding snow emergency parking for {}".format(finder.origin_address))
-            finder.start()
-            mycity_response.output_speech = finder.get_output_speech()
 
+    # If not provided, try to get the user address through geolocation and device address
+    coordinates = None
+    if intent_constants.CURRENT_ADDRESS_KEY not in mycity_request.session_attributes:
+        coordinates = address_utils.get_address_coordinates_from_geolocation(mycity_request)
+
+        if not coordinates: 
+            if mycity_request.device_has_geolocation:
+                return location_services_utils.request_geolocation_permission_response()
+
+            # Try getting device location
+            mycity_request, location_permissions = location_services_utils.get_address_from_user_device(mycity_request)
+            if not location_permissions:
+                return location_services_utils.request_device_address_permission_response()
+
+    
+    # If don't have coordinates or an address by now, ask the user
+    if not coordinates and intent_constants.CURRENT_ADDRESS_KEY not in mycity_request.session_attributes:
+        return user_address_intent.request_user_address_response(mycity_request)
+
+    try:
+        finder = FinderCSV(mycity_request, PARKING_INFO_URL, ADDRESS_KEY,
+                            constants.OUTPUT_SPEECH_FORMAT, format_record_fields,
+                            origin_coordinates = coordinates)
+    except InvalidAddressError:
+        mycity_response.output_speech = constants.ERROR_INVALID_ADDRESS
     else:
-        print("Error: Called snow_parking_intent with no address")
-        mycity_response.output_speech = constants.ERROR_SPEECH
+        finder_location_string = finder.origin_address if finder.origin_address \
+            else "{}, {}".format(finder.origin_coordinates['x'], finder.origin_coordinates['y'])
+        print("Finding snow emergency parking for {}".format(finder_location_string))
+        finder.start()
+        mycity_response.output_speech = finder.get_output_speech()
+
 
     # Setting reprompt_text to None signifies that we do not want to reprompt
     # the user. If the user does not respond or says something that is not

--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -130,10 +130,7 @@ def on_intent(mycity_request):
     elif mycity_request.intent_name == "TrashDayIntent":
         return get_trash_day_info(mycity_request)
     elif mycity_request.intent_name == "SnowParkingIntent":
-        return request_user_address_response(mycity_request) \
-            if intent_constants.CURRENT_ADDRESS_KEY \
-            not in mycity_request.session_attributes \
-            else get_snow_emergency_parking_intent(mycity_request)
+        return get_snow_emergency_parking_intent(mycity_request)
     elif mycity_request.intent_name == "CrimeIncidentsIntent":
         return request_user_address_response(mycity_request) \
             if intent_constants.CURRENT_ADDRESS_KEY \

--- a/mycity/mycity/test/integration_tests/test_snow_emergency_parking.py
+++ b/mycity/mycity/test/integration_tests/test_snow_emergency_parking.py
@@ -3,8 +3,11 @@ import unittest.mock as mock
 import mycity.test.integration_tests.intent_test_mixins as mix_ins
 import mycity.test.integration_tests.intent_base_case as base_case
 import mycity.test.test_constants as test_constants
+import mycity.intents.intent_constants as intent_constants
 import mycity.intents.snow_parking_intent as snow_parking
+from mycity.mycity_request_data_model import MyCityRequestDataModel
 
+import unittest
 
 
 ##########################################
@@ -85,5 +88,53 @@ class SnowEmergencyTestCase(mix_ins.RepromptTextTestMixIn,
         self.mock_address_candidates.stop()
         self.mock_api_access_token.stop()
         self.mock_closest_destination.stop()
+
+    def test_requests_geolocation_permissions_if_supported(self):
+        self.request._session_attributes.pop(intent_constants.CURRENT_ADDRESS_KEY, None)
+        self.request.device_has_geolocation = True
+        self.request.geolocation_permission = False
+        response = snow_parking.get_snow_emergency_parking_intent(self.request)
+        self.assertEqual(response.card_type, "AskForPermissionsConsent")
+
+    @mock.patch('mycity.intents.snow_parking_intent.location_services_utils.get_address_from_user_device')
+    def test_requests_device_address_if_supported(self, mock_get_address):
+        mock_get_address.return_value = (MyCityRequestDataModel(), False)
+        self.request._session_attributes.pop(intent_constants.CURRENT_ADDRESS_KEY, None)
+        self.request.device_has_geolocation = False
+        response = snow_parking.get_snow_emergency_parking_intent(self.request)
+        self.assertEqual(response.card_type, "AskForPermissionsConsent")
+
+    @mock.patch('mycity.intents.snow_parking_intent.location_services_utils.get_address_from_user_device')
+    def test_fallback_to_manual_request_if_no_device_address(self, mock_get_address):
+        mock_get_address.return_value = (MyCityRequestDataModel(), True)
+        self.request._session_attributes.pop(intent_constants.CURRENT_ADDRESS_KEY, None)
+        self.request.device_has_geolocation = False
+        response = snow_parking.get_snow_emergency_parking_intent(self.request)
+        self.assertEqual("Address", response.card_title)
+
+    def test_geolocation_finds_closest_parking(self):
+        self.request._session_attributes.pop(intent_constants.CURRENT_ADDRESS_KEY, None)
+        self.request.device_has_geolocation = True
+        self.request.geolocation_permission = True
+        self.request.geolocation_coordinates = {
+            "latitudeInDegrees": 42.316466,
+            "longitudeInDegrees": -71.056769,
+        }
+        response = snow_parking.get_snow_emergency_parking_intent(self.request)
+        self.assertEqual(self.expected_card_title, response.card_title)
+
+    @mock.patch('mycity.intents.snow_parking_intent.location_services_utils.get_address_from_user_device')
+    def test_device_address_finds_closest_parking(self, mock_get_address):
+        request_with_address = MyCityRequestDataModel()
+        request_with_address._session_attributes[intent_constants.CURRENT_ADDRESS_KEY] = "1000 Dorchester Ave"
+        mock_get_address.return_value = (request_with_address, True)
+
+        self.request._session_attributes.pop(intent_constants.CURRENT_ADDRESS_KEY, None)
+        self.request.device_has_geolocation = False
+        response = snow_parking.get_snow_emergency_parking_intent(self.request)
+        self.assertEqual(self.expected_card_title, response.card_title)
+
+if __name__ == '__main__':
+    unittest.main()
 
 

--- a/mycity/mycity/utilities/finder/FinderCSV.py
+++ b/mycity/mycity/utilities/finder/FinderCSV.py
@@ -27,7 +27,8 @@ class FinderCSV(Finder):
             address_key,
             output_speech,
             output_speech_prep_func,
-            filter = default_filter
+            filter = default_filter,
+            origin_coordinates = None
     ):
         """
         Call super constructor and save filter
@@ -48,6 +49,9 @@ class FinderCSV(Finder):
         :param filter: filter that we can use to remove records from csv
             file before using a service to find distances and 
             driving_times
+        :param origin_coordinates: coordinates to use as the orgin for
+            distance search. If None, will use the address in the req
+            parameter
         """
 
         super().__init__(
@@ -55,7 +59,8 @@ class FinderCSV(Finder):
             resource_url,
             address_key,
             output_speech,
-            output_speech_prep_func
+            output_speech_prep_func,
+            origin_coordinates
         )
         self._filter = filter
 


### PR DESCRIPTION
Closes #276 

This adds both geolocation and device address support to the snow parking intent. This will allow users to find either their current closest parking location or the parking location closest to their home.

Code to pay attention to in this review:
- Changes to `Finder.py`/`FinderCSV.py` to add support for searching by coordinate instead of by address
- Logic in `snow_parking_intent.py:47-64`, which adds the logic to determine what the origin location is (provided address, geolocation, or device address) and what permissions to request if needed

