### PR TITLE
278 add location services to crime incidents

### DIFF
--- a/mycity/mycity/intents/crime_activity_intent.py
+++ b/mycity/mycity/intents/crime_activity_intent.py
@@ -2,10 +2,19 @@
 
 import logging
 import mycity.intents.intent_constants as intent_constants
+from mycity.intents.user_address_intent \
+    import request_user_address_response
 from dateutil.parser import parse
+from mycity.utilities.location_services_utils \
+    import request_geolocation_permission_response, \
+    request_device_address_permission_response, \
+    get_address_from_user_device
+from mycity.utilities.address_utils \
+    import get_address_coordinates_from_geolocation
 from mycity.mycity_response_data_model import MyCityResponseDataModel
 from mycity.utilities.crime_incidents_api_utils import \
     get_crime_incident_response
+import mycity.utilities.gis_utils as gis_utils
 
 # Constants
 CARD_TITLE_CRIME = "Crime Report"
@@ -34,16 +43,38 @@ def get_crime_incidents_intent(mycity_request):
     """
     logger.debug('[method: get_crime_incidents_intent]')
 
-    mycity_response = MyCityResponseDataModel()
-    if intent_constants.CURRENT_ADDRESS_KEY in \
+    coordinates = {}
+    if intent_constants.CURRENT_ADDRESS_KEY not in \
             mycity_request.session_attributes:
-        address = mycity_request. \
-            session_attributes[intent_constants.CURRENT_ADDRESS_KEY]
-        response = get_crime_incident_response(address)
-        mycity_response.output_speech = \
-            _build_text_from_response(response)
-    else:
-        logger.debug("Error: Called crime_incidents_intent with no address")
+        coordinates = get_address_coordinates_from_geolocation(mycity_request)
+
+        if not coordinates:
+            if mycity_request.device_has_geolocation:
+                return request_geolocation_permission_response()
+
+            # Try getting registered device address
+            mycity_request, location_permissions \
+                = get_address_from_user_device(mycity_request)
+            if not location_permissions:
+                return request_device_address_permission_response()
+
+    # Convert address to coordinates if we only have user address
+    if intent_constants.CURRENT_ADDRESS_KEY \
+            in mycity_request.session_attributes:
+        current_address = mycity_request.session_attributes[
+            intent_constants.CURRENT_ADDRESS_KEY]
+        coordinates = gis_utils.geocode_address(current_address)
+
+    # If we don't have coordinates by now, and we have all required
+    #  permissions, ask the user for an address
+    if not coordinates:
+        return request_user_address_response(mycity_request)
+
+    mycity_response = MyCityResponseDataModel()
+
+    response = get_crime_incident_response(coordinates)
+    mycity_response.output_speech = \
+        _build_text_from_response(response)
 
     # Setting reprompt_text to None signifies that we do not want to reprompt
     # the user. If the user does not respond or says something that is not

--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -132,10 +132,7 @@ def on_intent(mycity_request):
     elif mycity_request.intent_name == "SnowParkingIntent":
         return get_snow_emergency_parking_intent(mycity_request)
     elif mycity_request.intent_name == "CrimeIncidentsIntent":
-        return request_user_address_response(mycity_request) \
-            if intent_constants.CURRENT_ADDRESS_KEY \
-            not in mycity_request.session_attributes \
-            else get_crime_incidents_intent(mycity_request)
+        return get_crime_incidents_intent(mycity_request)
     elif mycity_request.intent_name == "FoodTruckIntent":
         return get_nearby_food_trucks(mycity_request)
     elif mycity_request.intent_name == "GetAlertsIntent":

--- a/mycity/mycity/test/integration_tests/test_crime_incident_intent.py
+++ b/mycity/mycity/test/integration_tests/test_crime_incident_intent.py
@@ -1,9 +1,12 @@
 import unittest.mock as mock
+from mycity.mycity_request_data_model import MyCityRequestDataModel
 import mycity.test.test_constants as test_constants
 import mycity.test.integration_tests.intent_base_case as base_case
 import mycity.test.integration_tests.intent_test_mixins as mix_ins
 import mycity.intents.crime_activity_intent as crime_intent
+import mycity.intents.intent_constants as intent_constants
 
+import unittest
 
 ############################################
 # TestCase class for crime_incident_intent #
@@ -40,3 +43,64 @@ class CrimeIncidentsTestCase(mix_ins.RepromptTextTestMixIn,
     def tearDown(self):
         super().tearDown()
         self.get_crime_incident_response.stop()
+
+    def test_requests_geolocation_permissions_if_supported(self):
+        self.request._session_attributes.pop(
+            intent_constants.CURRENT_ADDRESS_KEY,
+            None)
+        self.request.device_has_geolocation = True
+        self.request.geolocation_permission = False
+        response = crime_intent.get_crime_incidents_intent(self.request)
+        self.assertEqual(response.card_type, "AskForPermissionsConsent")
+
+    @mock.patch('mycity.intents.crime_activity_intent.get_address_from_user_device')
+    def test_requests_device_address_if_supported(self, mock_get_address):
+        mock_get_address.return_value = (MyCityRequestDataModel(), False)
+        self.request._session_attributes.pop(
+            intent_constants.CURRENT_ADDRESS_KEY,
+            None)
+        self.request.device_has_geolocation = False
+        response = crime_intent.get_crime_incidents_intent(self.request)
+        self.assertEqual(response.card_type, "AskForPermissionsConsent")
+
+    @mock.patch('mycity.intents.crime_activity_intent.get_address_from_user_device')
+    def test_fallback_to_manual_request_if_no_device_address(self, mock_get_address):
+        mock_get_address.return_value = (MyCityRequestDataModel(), True)
+        self.request._session_attributes.pop(
+            intent_constants.CURRENT_ADDRESS_KEY, 
+            None)
+        self.request.device_has_geolocation = False
+        response = crime_intent.get_crime_incidents_intent(self.request)
+        self.assertEqual("Address", response.card_title)
+    
+    def test_geolocation_finds_closest_parking(self):
+        self.request._session_attributes.pop(
+            intent_constants.CURRENT_ADDRESS_KEY,
+            None)
+        self.request.device_has_geolocation = True
+        self.request.geolocation_permission = True
+        self.request.geolocation_coordinates = {
+            "latitudeInDegrees": 42.316466,
+            "longitudeInDegrees": -71.056769,
+        }
+        response = crime_intent.get_crime_incidents_intent(self.request)
+        self.assertEqual(self.expected_title, response.card_title)
+        self.assertTrue(response.output_speech)
+
+    @mock.patch('mycity.intents.crime_activity_intent.get_address_from_user_device')
+    def test_device_address_finds_closest_parking(self, mock_get_address):
+        request_with_address = MyCityRequestDataModel()
+        request_with_address._session_attributes[
+            intent_constants.CURRENT_ADDRESS_KEY] = "1000 Dorchester Ave"
+        mock_get_address.return_value = (request_with_address, True)
+
+        self.request._session_attributes.pop(
+            intent_constants.CURRENT_ADDRESS_KEY,
+            None)
+        self.request.device_has_geolocation = False
+        response = crime_intent.get_crime_incidents_intent(self.request)
+        self.assertEqual(self.expected_title, response.card_title)
+        self.assertTrue(response.output_speech)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mycity/mycity/test/unit_tests/test_crime_incidents_api_utils.py
+++ b/mycity/mycity/test/unit_tests/test_crime_incidents_api_utils.py
@@ -16,8 +16,10 @@ class CrimeIncidentsAPIUtilitiesTestCase(base.BaseTestCase):
             json_data=test_constants.GET_CRIME_INCIDENTS_API_MOCK)
         mock_get.return_value = mock_resp
 
-        test_address = "46 Everdean St Boston, MA"
-        result = get_crime_incident_response(test_address)
+        test_coords = {
+            'x': 42.316466,
+            'y': -71.056769}
+        result = get_crime_incident_response(test_coords)
         self.assertEqual(
             True,
             result['success']

--- a/mycity/mycity/utilities/crime_incidents_api_utils.py
+++ b/mycity/mycity/utilities/crime_incidents_api_utils.py
@@ -19,7 +19,8 @@ def get_crime_incident_response(origin_coordinates):
     """
     Executes and returns the crime incident request response
 
-    :param origin_coordinates: dictionary or origin_coordinates to query
+    :param origin_coordinates: dictionary of origin_coordinates to query.
+        Expects keys of 'x' and 'y'
     :return: the raw json response
 
     """

--- a/mycity/mycity/utilities/crime_incidents_api_utils.py
+++ b/mycity/mycity/utilities/crime_incidents_api_utils.py
@@ -15,17 +15,17 @@ CRIME_INCIDENTS_SQL_URL = \
 logger = logging.getLogger(__name__)
 
 
-def get_crime_incident_response(address):
+def get_crime_incident_response(origin_coordinates):
     """
     Executes and returns the crime incident request response
 
-    :param address: address to query
+    :param origin_coordinates: dictionary or origin_coordinates to query
     :return: the raw json response
 
     """
-    url_parameters = {"sql": _build_query_string(address)}
-    logger.debug("Finding crime incidents information for {} using query {}"
-        .format(address, url_parameters))
+    url_parameters = {"sql": _build_query_string(origin_coordinates)}
+    logger.debug("Finding crime incidents information for {}, {} using query {}"
+        .format(origin_coordinates['x'], origin_coordinates['y'], url_parameters))
     with requests.Session() as session:
         response = session.get(CRIME_INCIDENTS_SQL_URL, params=url_parameters)
 
@@ -34,33 +34,19 @@ def get_crime_incident_response(address):
     return {}
 
 
-def _build_query_string(address):
+def _build_query_string(origin_coordinates):
     """
     Builds the SQL query given an address
 
-    :param address: address to query
+    :param address: origin_coordinates to query
     :return: a SQL query string
 
     """
-    coordinates = _get_coordinates_for_address(address)
+    _lat = "{:.2f}".format(float(origin_coordinates['y']))
+    _long = "{:.2f}".format(float(origin_coordinates['x']))
     return """SELECT * FROM "{}" WHERE "Lat" LIKE '{}%' AND \
         "Long" LIKE '{}%' LIMIT {}""" \
         .format(RESOURCEID,
-                coordinates[0],
-                coordinates[1],
+                _lat,
+                _long,
                 QUERY_LIMIT)
-
-
-def _get_coordinates_for_address(address):
-    """
-    Populates the GPS coordinates for the provided address
-
-    :param address: address to query
-    :return: a tuple of the form (lat, long)
-
-    """
-    coordinates = geocode_address(address)
-    logger.debug("Got coordinates: {}".format(coordinates))
-    _lat = "{:.2f}".format(float(coordinates['y']))
-    _long = "{:.2f}".format(float(coordinates['x']))
-    return _lat, _long


### PR DESCRIPTION
Closes #278 

Adds logic in `mycity/mycity/intents/crime_activity_intent.py:46-71` to determine if we should use geocoding or device address for locating the nearest crime activity. Updated the API for `mycity/mycity/utilities/crime_incidents_api_utils.py` to take coordinates instead of address, since this is the only module that uses these functions and it was internally doing this conversion anyway. 