### PR TITLE
315 add covid intent

### DIFF
--- a/mycity/mycity/intents/coronavirus_update_intent.py
+++ b/mycity/mycity/intents/coronavirus_update_intent.py
@@ -1,0 +1,105 @@
+"""
+Retrives updates from boston.gov on the coronavirus impact
+"""
+
+from mycity.mycity_request_data_model import MyCityRequestDataModel
+from mycity.mycity_response_data_model import MyCityResponseDataModel
+from mycity.intents.custom_errors import ParseError
+
+from urllib import request
+from bs4 import BeautifulSoup
+
+INTENT_CARD_TITLE = "CORONAVIRUS (COVID-19) UPDATES"
+NO_UPDATE_ERROR = "I'm not able to find an update right now. Please try again later."
+
+WELCOME_MESSAGE = "Here are the latest updates:"
+HOMEPAGE_URL = "https://www.boston.gov"
+CORONAVIRUS_DETAIL_URL = "https://www.boston.gov/news/coronavirus-disease-covid-19-boston"
+
+
+def get_coronovirus_update(mycity_request):
+    """
+    Get the latest information about the coronavirus from boston.gov
+
+    :param mycity_request: MyCityRequestDataModel with the user request for information
+    :return: MyCityResponseDataModel containing information from boston.gov
+    """
+    mycity_response = MyCityResponseDataModel()
+    mycity_response.card_title = INTENT_CARD_TITLE
+    mycity_response.reprompt_text = None
+    mycity_response.session_attributes = mycity_request.session_attributes
+    mycity_response.should_end_session = True
+    try:
+        mycity_response.output_speech = _construct_output_speech(
+            _get_homepage_text(), _get_coronavirus_detail_text())
+    except ParseError:
+        mycity_response.output_speech = NO_UPDATE_ERROR
+
+    return mycity_response
+
+
+def _construct_output_speech(homepage_text, coronavirus_page_text):
+    """
+    Constructs output speech for the coronvirus update
+
+    :param homepage_text: String containing text from the homepage update
+    :param coronavirus_page_text: String containing text from the coronavirus detail webpage
+    :return: String for output speech
+    """
+    return WELCOME_MESSAGE + homepage_text + coronavirus_page_text
+
+
+def _get_html_parser(url):
+    """
+    Creates a BeautifulSoup parser
+
+    :param url: URL to read and create the parser for
+    :return: BeautifulSoup parser
+    """
+    url = request.urlopen(url)
+    parser = BeautifulSoup(url, "html.parser")
+    url.close()
+    return parser
+
+
+def _get_homepage_text():
+    """
+    Gets coronavirus update text from Boston.gov homepage
+
+    :return: String with coronavirus update text
+    """
+    parser = _get_html_parser(HOMEPAGE_URL)
+
+    try:
+        coronavirus_article = parser.find(
+            'article', about="/coronavirus-covid-19-updates")
+        text_div = coronavirus_article.find(
+            'div', class_='field-type-text-long')
+        return text_div.get_text()
+    except:
+        raise ParseError
+
+
+def _get_coronavirus_detail_text():
+    """
+    Get text from latest updates on the Boston.gov coronavirus detail page
+
+    :return: String with latest update text
+    """
+    parser = _get_html_parser(CORONAVIRUS_DETAIL_URL)
+
+    try:
+        all_items = parser.find('div', class_="field-type-text-with-summary")
+        found_first_address_tag = False
+        detail_text = ""
+        for child in all_items.children:
+            if child.name == 'address':
+                if found_first_address_tag:
+                    break
+                found_first_address_tag = True
+            elif child.name == "ul":
+                detail_text = detail_text + child.get_text()
+    except:
+        raise ParseError
+
+    return detail_text

--- a/mycity/mycity/intents/custom_errors.py
+++ b/mycity/mycity/intents/custom_errors.py
@@ -16,3 +16,6 @@ class MultipleAddressError(Exception):
     def __init__(self, addresses):
         self.addresses = addresses
 
+class ParseError(Exception):
+    """Error when parsing info from a webpage fails"""
+    pass

--- a/mycity/mycity/intents/feedback_intent.py
+++ b/mycity/mycity/intents/feedback_intent.py
@@ -9,7 +9,7 @@ import requests
 import json
 import os
 
-SLACK_WEBHOOKS_URL = os.environ['SLACK_WEBHOOKS_URL']
+SLACK_WEBHOOKS_URL = os.environ.get('SLACK_WEBHOOKS_URL', "Environment_missing_SLACK_WEBHOOKS_URL")
 CARD_TITLE = "Feedback"
 REPROMPT_TEXT = "In a few sentences or less, please describe the issue or feedback."
 

--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -5,20 +5,21 @@ This class handles all voice requests.
 """
 
 from mycity.mycity_response_data_model import MyCityResponseDataModel
-from .intents.user_address_intent import set_address_in_session, \
+from mycity.intents.user_address_intent import set_address_in_session, \
     get_address_from_session, request_user_address_response, \
     set_zipcode_in_session
 from mycity.intents.latest_311_intent import get_311_requests
-from .intents.trash_intent import get_trash_day_info
-from .intents.fallback_intent import fallback_intent
-from .intents.get_alerts_intent import get_alerts_intent, \
+from mycity.intents.trash_intent import get_trash_day_info
+from mycity.intents.fallback_intent import fallback_intent
+from mycity.intents.get_alerts_intent import get_alerts_intent, \
     get_inclement_weather_alert
-from .intents.snow_parking_intent import get_snow_emergency_parking_intent
-from .intents.feedback_intent import submit_feedback
-from .intents.crime_activity_intent import get_crime_incidents_intent
-from .intents.farmers_market_intent import get_farmers_markets_today
-from .intents.food_truck_intent import get_nearby_food_trucks
-from .intents import intent_constants
+from mycity.intents.snow_parking_intent import get_snow_emergency_parking_intent
+from mycity.intents.feedback_intent import submit_feedback
+from mycity.intents.coronavirus_update_intent import get_coronovirus_update
+from mycity.intents.crime_activity_intent import get_crime_incidents_intent
+from mycity.intents.farmers_market_intent import get_farmers_markets_today
+from mycity.intents.food_truck_intent import get_nearby_food_trucks
+from mycity.intents import intent_constants
 import logging
 
 logger = logging.getLogger(__name__)

--- a/mycity/mycity/mycity_controller.py
+++ b/mycity/mycity/mycity_controller.py
@@ -154,6 +154,8 @@ def on_intent(mycity_request):
         return get_inclement_weather_alert(mycity_request)
     elif mycity_request.intent_name == "FarmersMarketIntent":
         return get_farmers_markets_today(mycity_request)
+    elif mycity_request.intent_name == "CoronavirusUpdateIntent":
+        return get_coronovirus_update(mycity_request)
     else:
         raise ValueError("Invalid intent")
 

--- a/mycity/mycity/test/integration_tests/test_coronavirus_intent.py
+++ b/mycity/mycity/test/integration_tests/test_coronavirus_intent.py
@@ -1,0 +1,33 @@
+import unittest
+from mycity.mycity_request_data_model import MyCityRequestDataModel
+import mycity.intents.coronavirus_update_intent as coronavirus_update_intent
+import mycity.test.integration_tests.intent_base_case as base_case
+import mycity.test.integration_tests.intent_test_mixins as mix_ins
+
+########################################
+# TestCase class for CoronavirusIntent #
+########################################
+
+
+class CoronavirusIntentTestCase(base_case.IntentBaseCase,
+                                mix_ins.CardTitleTestMixIn,
+                                mix_ins.RepromptTextTestMixIn):
+
+    intent_to_test = "CoronavirusUpdateIntent"
+    expected_title = coronavirus_update_intent.INTENT_CARD_TITLE
+    returns_reprompt_text = False
+
+    def test_returns_session_attributes(self):
+        mycity_request = MyCityRequestDataModel()
+        mycity_request.session_attributes["test_key"] = "test_value"
+        mycity_response = coronavirus_update_intent.get_coronovirus_update(
+            mycity_request)
+        self.assertEqual(
+            "test_value", mycity_response.session_attributes["test_key"])
+
+    def test_returns_valid_text(self):
+        mycity_request = MyCityRequestDataModel()
+        mycity_reponse = coronavirus_update_intent.get_coronovirus_update(
+            mycity_request)
+        self.assertFalse(
+            coronavirus_update_intent.NO_UPDATE_ERROR in mycity_reponse.output_speech)

--- a/mycity/mycity/test/test_data/Boston.gov.html
+++ b/mycity/mycity/test/test_data/Boston.gov.html
@@ -1,0 +1,2814 @@
+<!DOCTYPE html>
+<!-- saved from url=(0023)https://www.boston.gov/ -->
+<html lang="en" dir="ltr" prefix="content: http://purl.org/rss/1.0/modules/content/  dc: http://purl.org/dc/terms/  foaf: http://xmlns.com/foaf/0.1/  og: http://ogp.me/ns#  rdfs: http://www.w3.org/2000/01/rdf-schema#  schema: http://schema.org/  sioc: http://rdfs.org/sioc/ns#  sioct: http://rdfs.org/sioc/types#  skos: http://www.w3.org/2004/02/skos/core#  xsd: http://www.w3.org/2001/XMLSchema# " style="" class=" no-touchevents details js flexbox"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <style data-styles="">cob-chart,cob-contact-form,cob-map{visibility:hidden}.hydrated{visibility:inherit}</style><script type="text/javascript" async="" src="./Boston.gov_files/analytics.js"></script><script type="text/javascript" async="" src="./Boston.gov_files/js"></script><script type="text/javascript" src="./Boston.gov_files/06206dff86"></script><script type="text/javascript" async="" src="./Boston.gov_files/analytics.js"></script><script src="./Boston.gov_files/nr-1167.min.js"></script><script src="./Boston.gov_files/gtm.js" async=""></script><script type="text/javascript">(window.NREUM||(NREUM={})).loader_config={licenseKey:"06206dff86",applicationID:"449797348"};window.NREUM||(NREUM={}),__nr_require=function(e,n,t){function r(t){if(!n[t]){var i=n[t]={exports:{}};e[t][0].call(i.exports,function(n){var i=e[t][1][n];return r(i||n)},i,i.exports)}return n[t].exports}if("function"==typeof __nr_require)return __nr_require;for(var i=0;i<t.length;i++)r(t[i]);return r}({1:[function(e,n,t){function r(){}function i(e,n,t){return function(){return o(e,[u.now()].concat(f(arguments)),n?null:this,t),n?void 0:this}}var o=e("handle"),a=e(4),f=e(5),c=e("ee").get("tracer"),u=e("loader"),s=NREUM;"undefined"==typeof window.newrelic&&(newrelic=s);var p=["setPageViewName","setCustomAttribute","setErrorHandler","finished","addToTrace","inlineHit","addRelease"],l="api-",d=l+"ixn-";a(p,function(e,n){s[n]=i(l+n,!0,"api")}),s.addPageAction=i(l+"addPageAction",!0),s.setCurrentRouteName=i(l+"routeName",!0),n.exports=newrelic,s.interaction=function(){return(new r).get()};var m=r.prototype={createTracer:function(e,n){var t={},r=this,i="function"==typeof n;return o(d+"tracer",[u.now(),e,t],r),function(){if(c.emit((i?"":"no-")+"fn-start",[u.now(),r,i],t),i)try{return n.apply(this,arguments)}catch(e){throw c.emit("fn-err",[arguments,this,e],t),e}finally{c.emit("fn-end",[u.now()],t)}}}};a("actionText,setName,setAttribute,save,ignore,onEnd,getContext,end,get".split(","),function(e,n){m[n]=i(d+n)}),newrelic.noticeError=function(e,n){"string"==typeof e&&(e=new Error(e)),o("err",[e,u.now(),!1,n])}},{}],2:[function(e,n,t){function r(e,n){var t=e.getEntries();t.forEach(function(e){"first-paint"===e.name?c("timing",["fp",Math.floor(e.startTime)]):"first-contentful-paint"===e.name&&c("timing",["fcp",Math.floor(e.startTime)])})}function i(e,n){var t=e.getEntries();t.length>0&&c("lcp",[t[t.length-1]])}function o(e){if(e instanceof s&&!l){var n,t=Math.round(e.timeStamp);n=t>1e12?Date.now()-t:u.now()-t,l=!0,c("timing",["fi",t,{type:e.type,fid:n}])}}if(!("init"in NREUM&&"page_view_timing"in NREUM.init&&"enabled"in NREUM.init.page_view_timing&&NREUM.init.page_view_timing.enabled===!1)){var a,f,c=e("handle"),u=e("loader"),s=NREUM.o.EV;if("PerformanceObserver"in window&&"function"==typeof window.PerformanceObserver){a=new PerformanceObserver(r),f=new PerformanceObserver(i);try{a.observe({entryTypes:["paint"]}),f.observe({entryTypes:["largest-contentful-paint"]})}catch(p){}}if("addEventListener"in document){var l=!1,d=["click","keydown","mousedown","pointerdown","touchstart"];d.forEach(function(e){document.addEventListener(e,o,!1)})}}},{}],3:[function(e,n,t){function r(e,n){if(!i)return!1;if(e!==i)return!1;if(!n)return!0;if(!o)return!1;for(var t=o.split("."),r=n.split("."),a=0;a<r.length;a++)if(r[a]!==t[a])return!1;return!0}var i=null,o=null,a=/Version\/(\S+)\s+Safari/;if(navigator.userAgent){var f=navigator.userAgent,c=f.match(a);c&&f.indexOf("Chrome")===-1&&f.indexOf("Chromium")===-1&&(i="Safari",o=c[1])}n.exports={agent:i,version:o,match:r}},{}],4:[function(e,n,t){function r(e,n){var t=[],r="",o=0;for(r in e)i.call(e,r)&&(t[o]=n(r,e[r]),o+=1);return t}var i=Object.prototype.hasOwnProperty;n.exports=r},{}],5:[function(e,n,t){function r(e,n,t){n||(n=0),"undefined"==typeof t&&(t=e?e.length:0);for(var r=-1,i=t-n||0,o=Array(i<0?0:i);++r<i;)o[r]=e[n+r];return o}n.exports=r},{}],6:[function(e,n,t){n.exports={exists:"undefined"!=typeof window.performance&&window.performance.timing&&"undefined"!=typeof window.performance.timing.navigationStart}},{}],ee:[function(e,n,t){function r(){}function i(e){function n(e){return e&&e instanceof r?e:e?c(e,f,o):o()}function t(t,r,i,o){if(!l.aborted||o){e&&e(t,r,i);for(var a=n(i),f=v(t),c=f.length,u=0;u<c;u++)f[u].apply(a,r);var p=s[y[t]];return p&&p.push([b,t,r,a]),a}}function d(e,n){h[e]=v(e).concat(n)}function m(e,n){var t=h[e];if(t)for(var r=0;r<t.length;r++)t[r]===n&&t.splice(r,1)}function v(e){return h[e]||[]}function g(e){return p[e]=p[e]||i(t)}function w(e,n){u(e,function(e,t){n=n||"feature",y[t]=n,n in s||(s[n]=[])})}var h={},y={},b={on:d,addEventListener:d,removeEventListener:m,emit:t,get:g,listeners:v,context:n,buffer:w,abort:a,aborted:!1};return b}function o(){return new r}function a(){(s.api||s.feature)&&(l.aborted=!0,s=l.backlog={})}var f="nr@context",c=e("gos"),u=e(4),s={},p={},l=n.exports=i();l.backlog=s},{}],gos:[function(e,n,t){function r(e,n,t){if(i.call(e,n))return e[n];var r=t();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(e,n,{value:r,writable:!0,enumerable:!1}),r}catch(o){}return e[n]=r,r}var i=Object.prototype.hasOwnProperty;n.exports=r},{}],handle:[function(e,n,t){function r(e,n,t,r){i.buffer([e],r),i.emit(e,n,t)}var i=e("ee").get("handle");n.exports=r,r.ee=i},{}],id:[function(e,n,t){function r(e){var n=typeof e;return!e||"object"!==n&&"function"!==n?-1:e===window?0:a(e,o,function(){return i++})}var i=1,o="nr@id",a=e("gos");n.exports=r},{}],loader:[function(e,n,t){function r(){if(!x++){var e=E.info=NREUM.info,n=d.getElementsByTagName("script")[0];if(setTimeout(s.abort,3e4),!(e&&e.licenseKey&&e.applicationID&&n))return s.abort();u(y,function(n,t){e[n]||(e[n]=t)}),c("mark",["onload",a()+E.offset],null,"api");var t=d.createElement("script");t.src="https://"+e.agent,n.parentNode.insertBefore(t,n)}}function i(){"complete"===d.readyState&&o()}function o(){c("mark",["domContent",a()+E.offset],null,"api")}function a(){return O.exists&&performance.now?Math.round(performance.now()):(f=Math.max((new Date).getTime(),f))-E.offset}var f=(new Date).getTime(),c=e("handle"),u=e(4),s=e("ee"),p=e(3),l=window,d=l.document,m="addEventListener",v="attachEvent",g=l.XMLHttpRequest,w=g&&g.prototype;NREUM.o={ST:setTimeout,SI:l.setImmediate,CT:clearTimeout,XHR:g,REQ:l.Request,EV:l.Event,PR:l.Promise,MO:l.MutationObserver};var h=""+location,y={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net",agent:"js-agent.newrelic.com/nr-1167.min.js"},b=g&&w&&w[m]&&!/CriOS/.test(navigator.userAgent),E=n.exports={offset:f,now:a,origin:h,features:{},xhrWrappable:b,userAgent:p};e(1),e(2),d[m]?(d[m]("DOMContentLoaded",o,!1),l[m]("load",r,!1)):(d[v]("onreadystatechange",i),l[v]("onload",r)),c("mark",["firstbyte",f],null,"api");var x=0,O=e(6)},{}],"wrap-function":[function(e,n,t){function r(e){return!(e&&e instanceof Function&&e.apply&&!e[a])}var i=e("ee"),o=e(5),a="nr@original",f=Object.prototype.hasOwnProperty,c=!1;n.exports=function(e,n){function t(e,n,t,i){function nrWrapper(){var r,a,f,c;try{a=this,r=o(arguments),f="function"==typeof t?t(r,a):t||{}}catch(u){l([u,"",[r,a,i],f])}s(n+"start",[r,a,i],f);try{return c=e.apply(a,r)}catch(p){throw s(n+"err",[r,a,p],f),p}finally{s(n+"end",[r,a,c],f)}}return r(e)?e:(n||(n=""),nrWrapper[a]=e,p(e,nrWrapper),nrWrapper)}function u(e,n,i,o){i||(i="");var a,f,c,u="-"===i.charAt(0);for(c=0;c<n.length;c++)f=n[c],a=e[f],r(a)||(e[f]=t(a,u?f+i:i,o,f))}function s(t,r,i){if(!c||n){var o=c;c=!0;try{e.emit(t,r,i,n)}catch(a){l([a,t,r,i])}c=o}}function p(e,n){if(Object.defineProperty&&Object.keys)try{var t=Object.keys(e);return t.forEach(function(t){Object.defineProperty(n,t,{get:function(){return e[t]},set:function(n){return e[t]=n,n}})}),n}catch(r){l([r])}for(var i in e)f.call(e,i)&&(n[i]=e[i]);return n}function l(n){try{e.emit("internal-error",n)}catch(t){}}return e||(e=i),t.inPlace=u,t.flag=a,t}},{}]},{},["loader"]);</script>
+<meta name="twitter:card" content="summary">
+<link rel="canonical" href="https://www.boston.gov/homepage">
+<meta property="og:site_name" content="Boston.gov">
+<link rel="shortlink" href="https://www.boston.gov/node/21">
+<meta name="description" content="Welcome to the official homepage for the City of Boston.">
+<meta property="og:type" content="website">
+<meta name="twitter:description" content="Welcome to the official homepage for the City of Boston.">
+<meta property="og:url" content="https://www.boston.gov">
+<meta name="generator" content="Drupal 8 (http://drupal.org)">
+<meta property="og:title" content="Homepage | Boston.gov">
+<meta property="og:description" content="Welcome to the official homepage for the City of Boston.">
+<meta property="og:image" content="http://patterns.boston.gov/images/global/icons/seal_dark_1000x1000.png">
+<meta property="og:image:secure_url" content="https://patterns.boston.gov/images/global/icons/seal_dark_1000x1000.png">
+<link rel="apple-touch-icon" sizes="180x180" href="https://www.boston.gov/themes/custom/bos_theme/images/apple-touch-icon.png">
+<meta property="og:locality" content="Boston">
+<meta property="og:region" content="Massachusetts">
+<link rel="apple-touch-icon-precomposed" sizes="180x180" href="https://www.boston.gov/themes/custom/bos_theme/images/apple-touch-icon-precomposed.png">
+<meta property="og:country_name" content="United States">
+<meta name="Generator" content="Drupal 8 (https://www.drupal.org)">
+<meta name="MobileOptimized" content="width">
+<meta name="HandheldFriendly" content="true">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@graph": [
+        {
+            "@type": "ImageObject",
+            "url": "https://patterns.boston.gov/images/global/icons/b-logo-large.png"
+        },
+        {
+            "@type": "WebSite",
+            "@id": "https://www.boston.gov/frontpage",
+            "name": "Boston.gov",
+            "url": "https://www.boston.gov"
+        }
+    ]
+}</script>
+<meta class="swiftype" name="site-priority" data-type="integer" content="5">
+<link rel="shortcut icon" href="https://www.boston.gov/themes/custom/bos_theme/images/favicon.ico" type="image/vnd.microsoft.icon">
+<link rel="alternate" hreflang="und" href="https://www.boston.gov/homepage">
+<link rel="revision" href="https://www.boston.gov/homepage">
+<script src="./Boston.gov_files/google_tag.script.js" defer=""></script>
+<style>.cd-ic-357556 {background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/2019/y/youtube-snip.png?itok=XbPTAjDm);
+    background-size: cover !important;}
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-357556 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/2019/y/youtube-snip.png?itok=FtIk0kLG); } }
+@media screen and (min-width: 0px) and (max-width: 419px) {
+    .cd-ic-357556 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_a_mobile/public/img/2019/y/youtube-snip.png?itok=bX2_UrWl); } }
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-357556 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/2019/y/youtube-snip.png?itok=0kO_fbyH); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-357556 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/2019/y/youtube-snip.png?itok=0kO_fbyH); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) {
+    .cd-ic-357556 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/2019/y/youtube-snip.png?itok=FtIk0kLG); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-357556 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/2019/y/youtube-snip.png?itok=0kO_fbyH); } }
+@media screen and (min-width: 768px) and (max-width: 839px) {
+    .cd-ic-357556 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/2019/y/youtube-snip.png?itok=0kO_fbyH); } }
+@media screen and (min-width: 840px) and (max-width: 1439px) {
+    .cd-ic-357556 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/2019/y/youtube-snip.png?itok=XbPTAjDm); } }
+@media screen and (min-width: 1440px) and (max-width: 1919px) {
+    .cd-ic-357556 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/2019/y/youtube-snip.png?itok=XbPTAjDm); } }
+@media screen and (min-width: 1920px) {
+    .cd-ic-357556 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/2019/y/youtube-snip.png?itok=XbPTAjDm); } }</style>
+<style>.cd-ic-357536 {background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.54.16%20AM.png?itok=FzoJru3i);
+    background-size: cover !important;}
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-357536 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.54.16%20AM.png?itok=mmenIsAY); } }
+@media screen and (min-width: 0px) and (max-width: 419px) {
+    .cd-ic-357536 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_a_mobile/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.54.16%20AM.png?itok=xrUXNM2O); } }
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-357536 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.54.16%20AM.png?itok=0ffqGDtM); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-357536 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.54.16%20AM.png?itok=0ffqGDtM); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) {
+    .cd-ic-357536 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.54.16%20AM.png?itok=mmenIsAY); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-357536 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.54.16%20AM.png?itok=0ffqGDtM); } }
+@media screen and (min-width: 768px) and (max-width: 839px) {
+    .cd-ic-357536 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.54.16%20AM.png?itok=0ffqGDtM); } }
+@media screen and (min-width: 840px) and (max-width: 1439px) {
+    .cd-ic-357536 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.54.16%20AM.png?itok=FzoJru3i); } }
+@media screen and (min-width: 1440px) and (max-width: 1919px) {
+    .cd-ic-357536 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.54.16%20AM.png?itok=FzoJru3i); } }
+@media screen and (min-width: 1920px) {
+    .cd-ic-357536 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.54.16%20AM.png?itok=FzoJru3i); } }</style>
+<style>.cd-ic-357546 {background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.41.00%20AM.png?itok=1f24COsT);
+    background-size: cover !important;}
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-357546 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.41.00%20AM.png?itok=iglw3qsI); } }
+@media screen and (min-width: 0px) and (max-width: 419px) {
+    .cd-ic-357546 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_a_mobile/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.41.00%20AM.png?itok=M9vDhbXT); } }
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-357546 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.41.00%20AM.png?itok=1Xvj8W1H); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-357546 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.41.00%20AM.png?itok=1Xvj8W1H); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) {
+    .cd-ic-357546 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.41.00%20AM.png?itok=iglw3qsI); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-357546 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.41.00%20AM.png?itok=1Xvj8W1H); } }
+@media screen and (min-width: 768px) and (max-width: 839px) {
+    .cd-ic-357546 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.41.00%20AM.png?itok=1Xvj8W1H); } }
+@media screen and (min-width: 840px) and (max-width: 1439px) {
+    .cd-ic-357546 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.41.00%20AM.png?itok=1f24COsT); } }
+@media screen and (min-width: 1440px) and (max-width: 1919px) {
+    .cd-ic-357546 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.41.00%20AM.png?itok=1f24COsT); } }
+@media screen and (min-width: 1920px) {
+    .cd-ic-357546 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-24%20at%2010.41.00%20AM.png?itok=1f24COsT); } }</style>
+
+    <title>Boston.gov</title>
+    <link rel="stylesheet" media="all" href="./Boston.gov_files/css_hZt_BoDw_ICq-GqWct6DQvETOxbCSHpSQQFFD5rU-VQ.css">
+<link rel="stylesheet" media="all" href="./Boston.gov_files/lity.min.css">
+<link rel="stylesheet" media="all" href="./Boston.gov_files/css_SgrZPheyXCa1BJ7zKcwKmeUfRAl3mkABHnEzmJYTPZY.css">
+
+<!--[if lte IE 9]><!-->
+<link rel="stylesheet" media="all" href="./Boston.gov_files/public.css">
+<!--<![endif]-->
+
+<!--[if lte IE 9]><!-->
+<link rel="stylesheet" media="all" href="./Boston.gov_files/public(1).css">
+<!--<![endif]-->
+<link rel="stylesheet" media="all" href="./Boston.gov_files/css_6oJnxXTl5t9fkw3C8uMRtGxwbWXLDmLm2glpmOsBgVY.css">
+
+<!--[if lt IE 10]>
+<link rel="stylesheet" media="all" href="https://patterns.boston.gov/css/ie.css" />
+<![endif]-->
+
+    
+<!--[if lte IE 8]>
+<script src="/sites/default/files/js/js_VtafjXmRvoUgAzqzYTA3Wrjkx9wcWhjP0G4ZnnqRamA.js"></script>
+<![endif]-->
+<script src="./Boston.gov_files/modernizr.min.js"></script>
+
+  <script src="./Boston.gov_files/fleetcomponents.ip6retou.js" type="module" crossorigin="true" data-resources-url="https://patterns.boston.gov/web-components/fleetcomponents/" data-namespace="fleetcomponents"></script></head>
+  <body class="html bos_theme front not-logged-in node-published page-node-21 page-node node-type-landing-page">
+          <p class="skip-link__wrapper" data-swiftype-index="false">
+        <a href="https://www.boston.gov/#main-menu" class="skip-link visually-hidden--focusable" id="skip-link" tabindex="-1">Jump to navigation</a>
+      </p>
+    
+    <noscript aria-hidden="true"><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TKGRDS" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      <div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas="">
+    
+<input type="checkbox" id="brg-tr" class="brg-tr" aria-hidden="true">
+
+<nav class="nv-m">
+  <div class="nv-m-h">
+    <div class="nv-m-h-ic">
+      <a href="https://www.boston.gov/" title="Go to home page">
+        <img src="./Boston.gov_files/b-dark.svg" alt="City of Boston" aria-hidden="true" class="nv-m-h-i">
+      </a>
+    </div>
+    <div id="nv-m-h-t" class="nv-m-h-t">&nbsp;</div>
+  </div>
+  <div class="nv-m-c">
+    <nav role="navigation" aria-labelledby="block-mainmenu-menu" id="block-mainmenu" data-block-plugin-id="menu_block:main">
+            
+  <h2 class="visually-hidden" id="block-mainmenu-menu">Main menu</h2>
+  
+
+        
+
+                            <ul class="nv-m-c-l">
+                                                                  <li class="nv-m-c-l-i is-l leaf first menu-mlid-763366 nv-m-c-a--y">
+                            <a href="http://www.cityofboston.gov/311/" title="" class="nv-m-c-a mv-m-c-a--p three-one-one">Help / 311</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-i is-l leaf menu-mlid-210101">
+                            <a href="https://www.boston.gov/homepage" class="nv-m-c-a mv-m-c-a--p is-active" data-drupal-link-system-path="node/21">Home</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-i is-l leaf menu-mlid-171721">
+                            <a href="https://www.boston.gov/guides" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/841">Guides to Boston</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-i is-l leaf menu-mlid-171726">
+                            <a href="https://www.boston.gov/departments" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/1796">Departments</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-i is-l leaf menu-mlid-1675906">
+                            <a href="https://www.boston.gov/public-notices" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/11666">Public Notices</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-i is-l leaf menu-mlid-2354776">
+                            <a href="https://www.boston.gov/pay-and-apply" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/32906">Pay and apply</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-i is-l leaf menu-mlid-2354781">
+                            <a href="https://www.boston.gov/career-center" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/19261">Work for the City</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-i is-l leaf menu-mlid-885866">
+                            <a href="https://www.boston.gov/events" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/1426">Events</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-i is-l leaf menu-mlid-202946">
+                            <a href="https://www.boston.gov/news" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/1401">News</a>
+                            </li>
+                                                          <li class="nv-m-c-l-i is-e expanded menu-mlid-171731">
+                <a href="https://www.boston.gov/#" title="" class="nv-m-c-a mv-m-c-a--p nolink nolink--a">Places</a>                  
+                                                              <ul class="nv-m-c-l-l nv-m-c-l-l--h">
+            <li class="nv-m-c-bc"><button class="nv-m-c-b">Back</button></li>
+                                                                  <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/cemeteries" title="" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/33006">Cemeteries</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/community-centers" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/32886">Community centers</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/departments/landmarks-commission#historic-districts" title="" class="nv-m-c-a mv-m-c-a--p">Historic Districts</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.bpl.org/" title="" class="nv-m-c-a mv-m-c-a--p">Libraries</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/neighborhoods" title="" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/33066">Neighborhoods</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/parks-and-playgrounds" title="" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/32946">Parks and playgrounds</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="http://www.bostonpublicschools.org/Page/628" title="" class="nv-m-c-a mv-m-c-a--p">Schools</a>
+                            </li>
+                            </ul>
+    
+                              </li>
+                                                          <li class="nv-m-c-l-i is-e expanded menu-mlid-171741 last">
+                <a href="https://www.boston.gov/#" title="" class="nv-m-c-a mv-m-c-a--p nolink nolink--a">Government</a>                  
+                                                              <ul class="nv-m-c-l-l nv-m-c-l-l--h">
+            <li class="nv-m-c-bc"><button class="nv-m-c-b">Back</button></li>
+                                                                  <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/departments/mayors-office" title="" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/176">The Mayor's Office</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/departments/city-council" title="" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/91">City Council</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/departments/city-clerk" title="" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/136">City Clerk</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/departments/election" title="" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/131">Elections</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/civic-engagement/boards-and-commissions" title="" class="nv-m-c-a mv-m-c-a--p">Boards and commissions</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/departments/311/city-boston-government" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/28101">City government</a>
+                            </li>
+                            </ul>
+    
+                              </li>
+                            </ul>
+    
+
+
+  </nav>
+
+
+  </div>
+</nav>
+
+<div class="ea mn page--fp" id="page" data-target="21">
+  <input type="checkbox" id="s-tr" class="s-tr" aria-hidden="true">
+
+  <header id="main-menu" class="h" role="banner" data-swiftype-index="false">
+    <label for="brg-tr" class="brg-b">
+  <div class="brg">
+    <span class="brg-c">
+      <span class="brg-c-i"></span>
+    </span>
+    <span class="brg-t"><span class="a11y--h">Toggle </span>Menu</span>
+  </div>
+</label>
+
+      <div class="lo lo--abs">
+    <div class="lo-l lo-b-cont">
+      <a href="https://www.boston.gov/">
+        <img src="./Boston.gov_files/logo.svg" alt="Boston.gov" class="lo-i">
+      </a>
+              <span class="lo-t"><a href="https://www.boston.gov/mayor">Mayor Martin J. Walsh</a></span>
+          </div>
+  </div>
+
+    <a id="seal" href="https://www.boston.gov/" title="Home" rel="home" class="s">
+  <img src="./Boston.gov_files/seal.svg" alt="City of Boston Seal" class="s-i">
+</a>
+
+    <nav class="nv-h">
+    <ul class="nv-h-l">
+        
+        
+                    <li class="nv-h-l-i">
+                <a href="https://www.boston.gov/pay-and-apply" title="" class="nv-h-l-a" data-drupal-link-system-path="node/32906">Pay and apply</a>
+            </li>
+                    <li class="nv-h-l-i">
+                <a href="https://www.boston.gov/public-notices" title="" class="nv-h-l-a" data-drupal-link-system-path="node/11666">Public notices</a>
+            </li>
+                    <li class="nv-h-l-i">
+                <a href="mailto:311supervisors@boston.gov" title="" class="nv-h-l-a" data-modal="feedback">Feedback</a>
+            </li>
+                    <li class="tr nv-h-l-i tr-dd-link--hidden translate-dropdown-menu tr--visible">
+            <a href="https://www.boston.gov/#translate" title="Translate" class="nv-h-l-a nv-h-l-a--k--s tr-link">Translate</a>
+            <ul class="tr-dd">
+                <li><span class="notranslate tr-dd-link tr-dd-link--message">Loading...</span></li>
+                <li><a href="https://www.boston.gov/#" class="notranslate tr-dd-link" data-ln="ht">Kreyòl Ayisyen</a></li>
+                <li><a href="https://www.boston.gov/#" class="notranslate tr-dd-link" data-ln="pt">Portugese</a></li>
+                <li><a href="https://www.boston.gov/#" class="notranslate tr-dd-link" data-ln="es">Español</a></li>
+                <li><a href="https://www.boston.gov/#" class="notranslate tr-dd-link" data-ln="vi">Tiếng Việt</a></li>
+                <li><a href="https://www.boston.gov/#" class="notranslate tr-dd-link tr-dd-link--hidden" data-ln="en">English</a></li>
+            </ul>
+        </li>
+        <li class="nv-h-l-i">
+            <label for="s-tr" title="Search" class="nv-h-l-a nv-h-l-a--k nv-h-l-a-ic" id="searchIcon">
+                <svg id="Layer_2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 41"><title>Search</title>
+                    <path class="nv-h-l-a-i" d="M24.2.6C15.8.6 9 7.4 9 15.8c0 3.7 1.4 7.2 3.6 9.8L1.2 37c-.8.8-.8 2 0 2.8.4.4.9.6 1.4.6s1-.2 1.4-.6l11.5-11.5C18 30 21 31 24.2 31c8.4 0 15.2-6.8 15.2-15.2C39.4 7.4 32.6.6 24.2.6zm0 26.5c-6.2 0-11.2-5-11.2-11.2S18 4.6 24.2 4.6s11.2 5 11.2 11.2-5 11.3-11.2 11.3z"></path>
+                </svg>
+            </label>
+        </li>
+    </ul>
+</nav>
+
+    <div class="h-s">
+  <form class="sf" action="https://www.boston.gov/search" accept-charset="UTF-8" method="get">
+    <input name="utf8" type="hidden" value="✓">
+    <div class="sf-i">
+      <input type="text" name="query" id="query" value="" placeholder="Search…" class="sf-i-f" autocomplete="off">
+      <button class="sf-i-b">Search</button>
+    </div>
+  </form>
+</div>
+
+  </header>
+
+          <div data-block-plugin-id="views_block:emergency_alerts-block_emergency_alert">
+      <div class="views-element-container"><div class="js-view-dom-id-6587c07152759fe886441957af11505af0d409f7aff5fbd6fb4286e1e98bbda1">
+  
+  
+  
+
+  
+  
+  
+
+      <div class="views-row"><article role="article" about="/coronavirus-covid-19-updates" class="node-11564406 node clearfix node-emergency-alert modstate-published" bos_context_type="Emergency Alert">
+  
+  <div class="b-c b-c--ntp b-c--nbp">
+    <div class="b b--fw b--cc b--dark-blue">
+      <div class="b-c">
+
+        <div class="t--upper t--sans lh--000">
+                      Last updated:             <time datetime="2020-04-24T14:50:29Z">Friday, April 24, 2020 - 10:50am</time>
+
+      
+                  </div>
+
+        <div class="str m-v300">
+          <div class="str-c">
+            <div class="str-t">
+              Coronavirus (COVID-19) updates
+            </div>
+          </div>
+        </div>
+
+        <div class="t--sans lh--000 m-b500">
+              <div class="field field-name-field-description field-type-text-long field-label-hidden field-items">
+                <div>
+        <p><u><a href="https://www.mass.gov/news/baker-polito-administration-announces-extension-of-school-and-non-emergency-child-care-0">All&nbsp;K-12 schools in Massachusetts</a></u> and non-emergency childcare programs are closed through the end of the school year.&nbsp;<u><a href="https://www.boston.gov/node/11565221">Strict measures are still in place in Boston</a></u>, including&nbsp;a Public Health Advisory for everyone except essential workers to stay at home from 9 p.m. to 6 a.m. each day.</p>
+
+            </div>
+          </div>
+
+        </div>
+
+                                  <a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston" target="_blank" class="btn">Coronavirus information</a>
+      
+
+
+              </div>
+    </div>
+  </div>
+</article>
+</div>
+
+    
+
+  
+  
+
+  
+  
+</div>
+</div>
+
+    </div>
+  
+
+  
+  <div class="main">
+    <div class="container">
+
+      <section class="main-content" id="content" role="main">
+        
+        <a href="https://www.boston.gov/#skip-link" class="visually-hidden--focusable" id="main-content" data-swiftype-index="false" tabindex="-1">Back to top</a>
+
+       
+                
+
+        
+        
+        
+
+        
+              <div data-drupal-messages-fallback="" class="hidden"></div><article class="node-21 node clearfix node-landing-page modstate-published" bos_context_type="Landing Page">
+      <header>
+
+      
+
+      
+
+    </header>
+  
+    
+            <div class="paragraphs-items paragraphs-items-field-components paragraphs-items-full paragraphs-items-field-components-full">
+                            <a></a>
+                
+<div class="entity entity-paragraphs-item component-section paragraphs-item-list b b--fw clearfix b--w" bos_context_type="List">
+  <div class="b-c b-c--ntp b-c--nbp">
+    
+    
+      
+<div id="statusHeader" class="b b--fw emergency-override-processed">
+
+  
+    <div class="m-b600">
+      <div class="b b--fw">
+        <div class="b-c b-c--nbp">
+          <div class="str">
+            <div class="str-c">
+                                            <div class="str-t">Saturday, April 25</div>
+                          </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  
+  
+    <div class="b-c b-c--ntp b-c--nbp">
+      <div class="p-b300">
+        <div class="g g--top">
+          
+                    
+
+  <div class="entity entity-paragraphs-item component-section paragraphs-item-message-for-the-day motd-422201 cds g--24" bos_context_type="Message For The Day">
+
+    
+      <a href="https://www.bostonpublicschools.org/coronavirus" class="cds-l d-b m-b500">
+
+    
+      <div class="cds-ic m-b500--l">
+
+        <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 66 66"><title>schools</title><circle cx="33" cy="33" r="31.42" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></circle><circle cx="32.95" cy="33.8" r="31.42" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></circle><path d="M55.2,24.08,33.89,15.57a2.43,2.43,0,0,0-1.76,0l-21.3,8.51a2.37,2.37,0,0,0-.08,4.37L12,29l.72.32v9.26a2.7,2.7,0,0,0,0,5v1.71a1,1,0,0,0,2,0V43.58a2.7,2.7,0,0,0,0-5V30.19l.88.39,2.11.93,2.52,1.12,11.86,5.24a2.38,2.38,0,0,0,1.92,0l11.87-5.24,2.51-1.12,6.93-3.06A2.37,2.37,0,0,0,55.2,24.08ZM33,27h-.24a3.27,3.27,0,0,1-1.4-.34c-.28-.15-.45-.34-.45-.54a.15.15,0,0,1,0-.09.06.06,0,0,1,0,0c.14-.43,1-.75,2.06-.75s2.09.39,2.09.88S34.17,27,33,27Z" fill="#0c1f2e"></path><path d="M33.47,40.79,45.81,35a1.13,1.13,0,0,1,1.58,1.09v8.73a1.16,1.16,0,0,1-1,1.19c-4.17.26-10.69,5-12.72,6.48a1.07,1.07,0,0,1-1.26,0c-2.06-1.45-8.64-5.89-12.77-6.36a1.15,1.15,0,0,1-1-1.18V36.06A1.12,1.12,0,0,1,20.21,35l12.35,5.82A1,1,0,0,0,33.47,40.79Z" fill="#0c1f2e"></path></svg>
+
+                  <svg class="cds-ia" width="28" height="28" viewBox="-1187 1989 24 24" xmlns="http://www.w3.org/2000/svg"><title>Alert</title><desc>A red exclamation point in a cirlce.</desc><circle class="svg-stroke-hover" stroke="#FB4D42" stroke-width="3" fill="#FFF" fill-rule="evenodd" cx="-1175" cy="2001" r="10.5"></circle><path d="M-1175 2008.2c-.4 0-.8-.1-1.1-.4-.3-.3-.4-.6-.4-1s.1-.8.4-1c.3-.3.6-.4 1.1-.4.4 0 .8.1 1 .4.2.3.4.6.4 1s-.1.8-.4 1c-.3.2-.6.4-1 .4zm-1.4-14.4h2.8v2.6l-.6 7.2h-1.6l-.6-7.2v-2.6z" class="svg-fill-hover" fill="#FB4D42" fill-rule="evenodd"></path></svg>
+
+        
+      </div>
+
+      <div class="cds-c">
+
+        <div class="cds-t t--upper t--sans m-b300">
+          Schools closed
+        </div>
+
+        <div class="cds-d t--subinfo">
+              <div class="field field-name-field-message field-type-text-long field-label-hidden field-items">
+                <div>
+        <p>Governor Baker announced the closure of K-12 schools in Massachusetts and non-emergency childcare programs through the end of the school year.&nbsp;</p>
+
+            </div>
+          </div>
+
+        </div>
+
+      </div>
+
+          </a>
+    
+  </div>
+
+
+      
+  
+                    
+
+  <div class="entity entity-paragraphs-item component-section paragraphs-item-message-for-the-day motd-389206 cds g--24" bos_context_type="Message For The Day">
+
+    
+      <a href="https://www.boston.gov/departments/311/city-owned-buildings-boston" class="cds-l d-b m-b500">
+
+    
+      <div class="cds-ic m-b500--l">
+
+        <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 66 66"><title>building</title><circle cx="33" cy="33" r="31.42" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></circle><polygon points="40.34 31.83 40.34 20.16 28.36 20.16 28.36 18.16 24.36 18.16 24.36 20.16 21.09 20.16 21.09 49.16 29.46 49.16 40.34 49.16 48.71 49.16 48.71 31.83 40.34 31.83" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></polygon><rect x="24.36" y="41.91" width="4" height="4" fill="#091f2f"></rect><rect x="33.24" y="41.91" width="4" height="4" fill="#091f2f"></rect><rect x="42.11" y="41.91" width="4" height="4" fill="#091f2f"></rect><rect x="24.36" y="35.87" width="4" height="4" fill="#091f2f"></rect><rect x="33.24" y="35.87" width="4" height="4" fill="#091f2f"></rect><rect x="42.11" y="35.87" width="4" height="4" fill="#091f2f"></rect><rect x="24.36" y="29.83" width="4" height="4" fill="#091f2f"></rect><rect x="33.24" y="29.83" width="4" height="4" fill="#091f2f"></rect><rect x="24.36" y="23.79" width="4" height="4" fill="#091f2f"></rect><rect x="33.24" y="23.79" width="4" height="4" fill="#091f2f"></rect></svg>
+
+                  <svg class="cds-ia" width="28" height="28" viewBox="-1187 1989 24 24" xmlns="http://www.w3.org/2000/svg"><title>Alert</title><desc>A red exclamation point in a cirlce.</desc><circle class="svg-stroke-hover" stroke="#FB4D42" stroke-width="3" fill="#FFF" fill-rule="evenodd" cx="-1175" cy="2001" r="10.5"></circle><path d="M-1175 2008.2c-.4 0-.8-.1-1.1-.4-.3-.3-.4-.6-.4-1s.1-.8.4-1c.3-.3.6-.4 1.1-.4.4 0 .8.1 1 .4.2.3.4.6.4 1s-.1.8-.4 1c-.3.2-.6.4-1 .4zm-1.4-14.4h2.8v2.6l-.6 7.2h-1.6l-.6-7.2v-2.6z" class="svg-fill-hover" fill="#FB4D42" fill-rule="evenodd"></path></svg>
+
+        
+      </div>
+
+      <div class="cds-c">
+
+        <div class="cds-t t--upper t--sans m-b300">
+          City building hours
+        </div>
+
+        <div class="cds-d t--subinfo">
+              <div class="field field-name-field-message field-type-text-long field-label-hidden field-items">
+                <div>
+        <p>City Hall will only be open to the public&nbsp;on&nbsp;Tuesdays and Fridays, from 9 a.m. to 5 p.m. All library locations and BCYF community centers are closed.</p>
+
+            </div>
+          </div>
+
+        </div>
+
+      </div>
+
+          </a>
+    
+  </div>
+
+
+              
+
+              
+
+              
+
+      
+  
+                    
+
+  <div class="entity entity-paragraphs-item component-section paragraphs-item-message-for-the-day motd-414246 cds g--24" bos_context_type="Message For The Day">
+
+    
+      <a href="https://www.boston.gov/news/covid-19-status-city-boston-departments" class="cds-l d-b m-b500">
+
+    
+      <div class="cds-ic m-b500--l">
+
+        <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 66 66"><title>city_hall_municipal_offices</title><circle cx="33" cy="33" r="31.42" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></circle><circle cx="32.92" cy="33" r="31.42" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></circle><rect x="24.95" y="38.48" width="8.45" height="13.57" fill="#fff" stroke="#0c1f2e" stroke-miterlimit="10" stroke-width="2"></rect><rect x="20.22" y="31.69" width="24.38" height="7.76" fill="#fff" stroke="#0c1f2e" stroke-miterlimit="10" stroke-width="2"></rect><rect x="8.06" y="39.05" width="20.88" height="5.13" transform="translate(60.11 23.12) rotate(90)" fill="#fff" stroke="#0c1f2e" stroke-miterlimit="10" stroke-width="2"></rect><rect x="36.01" y="39.05" width="20.88" height="5.13" transform="translate(88.07 -4.84) rotate(90)" fill="#fff" stroke="#0c1f2e" stroke-miterlimit="10" stroke-width="2"></rect><rect x="10.45" y="16.18" width="43.94" height="7.76" fill="#fff" stroke="#0c1f2e" stroke-miterlimit="10" stroke-width="2"></rect><rect x="16.01" y="23.94" width="32.8" height="7.76" fill="#fff" stroke="#0c1f2e" stroke-miterlimit="10" stroke-width="2"></rect><rect x="13.45" y="18.55" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="18.44" y="18.55" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="23.42" y="18.55" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="28.41" y="18.55" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="33.4" y="18.55" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="43.37" y="18.55" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="38.39" y="18.55" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="48.36" y="18.55" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="18.44" y="26.05" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="23.42" y="26.05" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="28.41" y="26.05" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="33.4" y="26.05" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="38.39" y="26.05" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="43.37" y="26.05" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="28.41" y="34.06" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="33.4" y="34.06" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="33.38" y="34.06" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="38.37" y="34.06" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="23.44" y="34.06" width="3.02" height="3.02" fill="#0c1f2e"></rect><rect x="21.06" y="47.01" width="17.32" height="5.04" fill="#fff" stroke="#0c1f2e" stroke-miterlimit="10" stroke-width="2"></rect></svg>
+
+                  <svg class="cds-ia" width="28" height="28" viewBox="-1187 1989 24 24" xmlns="http://www.w3.org/2000/svg"><title>Alert</title><desc>A red exclamation point in a cirlce.</desc><circle class="svg-stroke-hover" stroke="#FB4D42" stroke-width="3" fill="#FFF" fill-rule="evenodd" cx="-1175" cy="2001" r="10.5"></circle><path d="M-1175 2008.2c-.4 0-.8-.1-1.1-.4-.3-.3-.4-.6-.4-1s.1-.8.4-1c.3-.3.6-.4 1.1-.4.4 0 .8.1 1 .4.2.3.4.6.4 1s-.1.8-.4 1c-.3.2-.6.4-1 .4zm-1.4-14.4h2.8v2.6l-.6 7.2h-1.6l-.6-7.2v-2.6z" class="svg-fill-hover" fill="#FB4D42" fill-rule="evenodd"></path></svg>
+
+        
+      </div>
+
+      <div class="cds-c">
+
+        <div class="cds-t t--upper t--sans m-b300">
+          Status of City departments
+        </div>
+
+        <div class="cds-d t--subinfo">
+              <div class="field field-name-field-message field-type-text-long field-label-hidden field-items">
+                <div>
+        <p>Many departments have closed their offices&nbsp;to the public. If you need to visit City Hall for essential services, you must&nbsp;make an appointment.</p>
+
+            </div>
+          </div>
+
+        </div>
+
+      </div>
+
+          </a>
+    
+  </div>
+
+
+      
+  
+                    
+
+  <div class="entity entity-paragraphs-item component-section paragraphs-item-message-for-the-day motd-389221 cds g--24" bos_context_type="Message For The Day">
+
+    
+      <a href="https://www.boston.gov/trash-and-recycling-day-schedule-and-search" class="cds-l d-b m-b500">
+
+    
+      <div class="cds-ic m-b500--l">
+
+        <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 66 66"><title>trash_and_Recycling</title><circle cx="32.9" cy="33" r="31.42" fill="#fff"></circle><circle cx="32.9" cy="33" r="31.42" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></circle><rect x="22.65" y="19.16" width="20.5" height="4.07" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></rect><rect x="28.23" y="14.97" width="9.35" height="2.03" fill="#091f2f"></rect><polygon points="39.22 49.42 26.58 49.42 23.95 27.24 41.85 27.24 39.22 49.42" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3" fill-rule="evenodd"></polygon></svg>
+
+                  <svg class="cds-ia" width="28" height="28" viewBox="-1187 1989 24 24" xmlns="http://www.w3.org/2000/svg"><title>Alert</title><desc>A red exclamation point in a cirlce.</desc><circle class="svg-stroke-hover" stroke="#FB4D42" stroke-width="3" fill="#FFF" fill-rule="evenodd" cx="-1175" cy="2001" r="10.5"></circle><path d="M-1175 2008.2c-.4 0-.8-.1-1.1-.4-.3-.3-.4-.6-.4-1s.1-.8.4-1c.3-.3.6-.4 1.1-.4.4 0 .8.1 1 .4.2.3.4.6.4 1s-.1.8-.4 1c-.3.2-.6.4-1 .4zm-1.4-14.4h2.8v2.6l-.6 7.2h-1.6l-.6-7.2v-2.6z" class="svg-fill-hover" fill="#FB4D42" fill-rule="evenodd"></path></svg>
+
+        
+      </div>
+
+      <div class="cds-c">
+
+        <div class="cds-t t--upper t--sans m-b300">
+          Trash and recycling
+        </div>
+
+        <div class="cds-d t--subinfo">
+              <div class="field field-name-field-message field-type-text-long field-label-hidden field-items">
+                <div>
+        <p>Due to the holiday, pickups are delayed in some neighborhoods this week. Please check your schedule.</p>
+
+            </div>
+          </div>
+
+        </div>
+
+      </div>
+
+          </a>
+    
+  </div>
+
+
+              
+
+              
+
+      
+  
+                    
+
+              
+
+  <div class="entity entity-paragraphs-item component-section paragraphs-item-message-for-the-day motd-396641 cds g--24" bos_context_type="Message For The Day">
+
+    
+      <a href="https://www.boston.gov/departments/public-works/street-sweeping-city" class="cds-l d-b m-b500">
+
+    
+      <div class="cds-ic m-b500--l">
+
+        <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 66 66"><title>street_sweeping</title><circle cx="33" cy="33" r="31.42" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></circle><path d="M36.86,24.58,49.14,14,38.52,26.76S38,24.91,36.86,24.58Z" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></path><path d="M14.26,35.49a16.32,16.32,0,0,0,4.24,7.45,26.76,26.76,0,0,0,8.59,5.28C28.66,42.34,33,39,34.89,37c3.41-3.43,3-7.44.42-10s-6.48-2.8-9.89.63C23.5,29.56,17.57,34.77,14.26,35.49Z" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></path><line x1="24.41" y1="28.57" x2="33.93" y2="38.02" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><polygon points="20.19 37 15.32 38.42 17.11 41.34 20.19 37" fill="#091f2f"></polygon><path d="M25.81,40.41s-2,5.38-.95,6.84-1.7-1.16-1.7-1.16S22.87,43.34,25.81,40.41Z" fill="#091f2f"></path><path d="M25.59,37s-3.21,3.41-3.84,6.66l-2.94-.75-.19-1.32A22.59,22.59,0,0,0,25.59,37Z" fill="#091f2f"></path><circle cx="37.05" cy="47.37" r="3.12" fill="#091f2f"></circle><circle cx="45.32" cy="43.08" r="2.32" fill="#091f2f"></circle><circle cx="43.52" cy="53.15" r="1.51" fill="#091f2f"></circle></svg>
+
+                  <svg class="cds-ia" width="28" height="28" viewBox="-1187 1989 24 24" xmlns="http://www.w3.org/2000/svg"><title>Alert</title><desc>A red exclamation point in a cirlce.</desc><circle class="svg-stroke-hover" stroke="#FB4D42" stroke-width="3" fill="#FFF" fill-rule="evenodd" cx="-1175" cy="2001" r="10.5"></circle><path d="M-1175 2008.2c-.4 0-.8-.1-1.1-.4-.3-.3-.4-.6-.4-1s.1-.8.4-1c.3-.3.6-.4 1.1-.4.4 0 .8.1 1 .4.2.3.4.6.4 1s-.1.8-.4 1c-.3.2-.6.4-1 .4zm-1.4-14.4h2.8v2.6l-.6 7.2h-1.6l-.6-7.2v-2.6z" class="svg-fill-hover" fill="#FB4D42" fill-rule="evenodd"></path></svg>
+
+        
+      </div>
+
+      <div class="cds-c">
+
+        <div class="cds-t t--upper t--sans m-b300">
+          Street Cleaning
+        </div>
+
+        <div class="cds-d t--subinfo">
+              <div class="field field-name-field-message field-type-text-long field-label-hidden field-items">
+                <div>
+        <p><em>Street cleaning is on a normal schedule. However, we are not ticketing or towing for street sweeping at this time.</em></p>
+
+            </div>
+          </div>
+
+        </div>
+
+      </div>
+
+          </a>
+    
+  </div>
+
+
+              
+
+              
+
+      
+  
+                    
+
+              
+
+  <div class="entity entity-paragraphs-item component-section paragraphs-item-message-for-the-day motd-386296 cds g--24" bos_context_type="Message For The Day">
+
+    
+      <a href="https://www.boston.gov/departments/parking-clerk/how-do-parking-meters-work" class="cds-l d-b m-b500">
+
+    
+      <div class="cds-ic m-b500--l">
+
+        <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 66 66"><title>parking_meters</title><circle cx="33" cy="33" r="31.42" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></circle><path d="M20.5,20c0-.07-.41,0-.39,0h8.07a5.68,5.68,0,0,1,4-2,5.66,5.66,0,0,1,4,2h8.19s-.16-.87-.23-1.11c-.12-.39-.26-1-.42-1.34s-.25-.62-.38-.86-.2-.46-.22-.5c-.11-.19-.5-.84-.59-1s-.24-.36-.37-.53L42,14.52c-.06-.07-.12-.13-.17-.2-.21-.25-.42-.5-.64-.73L41,13.38c-.09-.09-.2-.17-.29-.25s-.47-.43-.71-.63a.69.69,0,0,1-.13-.11c-.24-.18-.47-.37-.72-.53s-.35-.22-.52-.32l-.22-.13c-.1-.06-.19-.13-.29-.18a12.42,12.42,0,0,0-4.68-1.44,10.86,10.86,0,0,0-1.28-.07c-.35,0-.69,0-1,0l-.28,0c-.25,0-.49,0-.74.09l-.28.06a5.93,5.93,0,0,0-.73.16l-.24.06c-.26.07-.51.15-.77.24l-.15.05c-.29.11-.58.22-.86.35h0a12.7,12.7,0,0,0-1.88,1,10.1,10.1,0,0,0-.84.62c-.35.26-.69,1-1,1.29A15.13,15.13,0,0,0,20,20h.06Z" fill="#091f2f"></path><polygon points="20.09 23.58 23.35 47 31 47 31 57 35 57 35 47 41.77 47 44.8 23.58 20.09 23.58" fill="#091f2f"></polygon></svg>
+
+                  <svg class="cds-ia" width="28" height="28" viewBox="-1187 1989 24 24" xmlns="http://www.w3.org/2000/svg"><title>Alert</title><desc>A red exclamation point in a cirlce.</desc><circle class="svg-stroke-hover" stroke="#FB4D42" stroke-width="3" fill="#FFF" fill-rule="evenodd" cx="-1175" cy="2001" r="10.5"></circle><path d="M-1175 2008.2c-.4 0-.8-.1-1.1-.4-.3-.3-.4-.6-.4-1s.1-.8.4-1c.3-.3.6-.4 1.1-.4.4 0 .8.1 1 .4.2.3.4.6.4 1s-.1.8-.4 1c-.3.2-.6.4-1 .4zm-1.4-14.4h2.8v2.6l-.6 7.2h-1.6l-.6-7.2v-2.6z" class="svg-fill-hover" fill="#FB4D42" fill-rule="evenodd"></path></svg>
+
+        
+      </div>
+
+      <div class="cds-c">
+
+        <div class="cds-t t--upper t--sans m-b300">
+          Parking meters
+        </div>
+
+        <div class="cds-d t--subinfo">
+              <div class="field field-name-field-message field-type-text-long field-label-hidden field-items">
+                <div>
+        <p>Residents with a valid resident parking permit sticker can park in a metered or two-hour parking space in their neighborhood&nbsp;without having to adhere to the time limit, or pay a meter fee.</p>
+
+            </div>
+          </div>
+
+        </div>
+
+      </div>
+
+          </a>
+    
+  </div>
+
+
+              
+
+              
+
+      
+  
+                    
+
+              
+
+  <div class="entity entity-paragraphs-item component-section paragraphs-item-message-for-the-day motd-386256 cds g--24" bos_context_type="Message For The Day">
+
+    
+      <a href="https://www.boston.gov/departments/transportation/how-get-your-towed-car-back" class="cds-l d-b m-b500">
+
+    
+      <div class="cds-ic m-b500--l">
+
+        <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 66 66"><title>tow_lot</title><circle cx="33" cy="33" r="31.42" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></circle><path d="M28,34.08l0-9.24H20L17.69,29.7a56.15,56.15,0,0,0-6.32,1.69l-.37.13v7.83H55V34.08Zm-1.89-1.43H19.79v-2.1L21.46,27h4.61Z" fill="#091f2f"></path><circle cx="19.34" cy="40.4" r="4" fill="#091f2f"></circle><path d="M19.34,45a4.55,4.55,0,1,1,4.55-4.55A4.55,4.55,0,0,1,19.34,45Zm0-8A3.46,3.46,0,1,0,22.8,40.4,3.46,3.46,0,0,0,19.34,36.94Z" fill="#091f2f"></path><circle cx="48.39" cy="40.4" r="4" fill="#091f2f"></circle><path d="M48.39,45a4.55,4.55,0,1,1,4.55-4.55A4.55,4.55,0,0,1,48.39,45Zm0-8a3.46,3.46,0,1,0,3.46,3.46A3.46,3.46,0,0,0,48.39,36.94Z" fill="#091f2f"></path><circle cx="19.29" cy="40.34" r="1.82" fill="#091f2f"></circle><path d="M19.29,42.71a2.37,2.37,0,1,1,2.36-2.37A2.37,2.37,0,0,1,19.29,42.71Zm0-3.64a1.27,1.27,0,1,0,1.27,1.27A1.27,1.27,0,0,0,19.29,39.07Z" fill="#091f2f"></path><polygon points="27.4 30.66 30.5 33.82 52.38 22.54 52.88 20.51 27.4 30.66" fill="#091f2f"></polygon><circle cx="48.34" cy="40.34" r="1.82" fill="#091f2f"></circle><path d="M48.34,42.71a2.37,2.37,0,1,1,2.36-2.37A2.37,2.37,0,0,1,48.34,42.71Zm0-3.64a1.27,1.27,0,1,0,1.27,1.27A1.27,1.27,0,0,0,48.34,39.07Z" fill="#091f2f"></path><path d="M26,25.11H21.83l1-3.85h2.27Z" fill="#091f2f"></path><circle cx="52.81" cy="27.12" r="1.38" fill="#091f2f"></circle><path d="M53,27.12v2.77a1.53,1.53,0,0,1,.84,1.2,1.2,1.2,0,0,1-1.2,1.29,1.17,1.17,0,0,1-1.1-1.25" fill="none" stroke="#091f2f" stroke-miterlimit="10"></path><line x1="52.81" y1="25.74" x2="52.81" y2="20.63" fill="none" stroke="#091f2f" stroke-miterlimit="10"></line><rect x="26.07" y="31.25" width="16.8" height="5.14" fill="#091f2f"></rect></svg>
+
+                  <svg class="cds-ia" width="28" height="28" viewBox="-1187 1989 24 24" xmlns="http://www.w3.org/2000/svg"><title>Alert</title><desc>A red exclamation point in a cirlce.</desc><circle class="svg-stroke-hover" stroke="#FB4D42" stroke-width="3" fill="#FFF" fill-rule="evenodd" cx="-1175" cy="2001" r="10.5"></circle><path d="M-1175 2008.2c-.4 0-.8-.1-1.1-.4-.3-.3-.4-.6-.4-1s.1-.8.4-1c.3-.3.6-.4 1.1-.4.4 0 .8.1 1 .4.2.3.4.6.4 1s-.1.8-.4 1c-.3.2-.6.4-1 .4zm-1.4-14.4h2.8v2.6l-.6 7.2h-1.6l-.6-7.2v-2.6z" class="svg-fill-hover" fill="#FB4D42" fill-rule="evenodd"></path></svg>
+
+        
+      </div>
+
+      <div class="cds-c">
+
+        <div class="cds-t t--upper t--sans m-b300">
+          Tow lot
+        </div>
+
+        <div class="cds-d t--subinfo">
+              <div class="field field-name-field-message field-type-text-long field-label-hidden field-items">
+                <div>
+        <p>The tow lot is open Monday through Friday, 9:30 a.m. - 4:30 p.m. Automated kiosks are available 24 hours a day, seven days a week for vehicle releases.</p>
+
+            </div>
+          </div>
+
+        </div>
+
+      </div>
+
+          </a>
+    
+  </div>
+
+
+              
+
+              
+
+              
+
+      
+  
+                    
+
+  <div class="entity entity-paragraphs-item component-section paragraphs-item-message-for-the-day motd-411241 cds g--24" bos_context_type="Message For The Day">
+
+    
+      <a href="https://www.boston.gov/departments/food-access/map-meal-sites-boston" class="cds-l d-b m-b500">
+
+    
+      <div class="cds-ic m-b500--l">
+
+        <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 66 66"><title>food</title><circle cx="33" cy="33" r="31.42" fill="#fff"></circle><circle cx="33" cy="33" r="31.42" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></circle><polyline points="49.07 20.08 49.07 27.57 52.73 31.03 56.39 27.57 56.39 20.08" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></polyline><line x1="52.75" y1="20.08" x2="52.75" y2="30.68" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><line x1="52.75" y1="31.42" x2="52.75" y2="47.86" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><path d="M13.06,47.86V21.23C9.7,21.23,9.31,25,9.31,25V36.5h3.75" fill="#091f2f" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></path><circle cx="31.29" cy="33.39" r="12.46" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></circle><circle cx="33.05" cy="32.95" r="30.78" fill="none" stroke="#091f2f" stroke-width="3.26"></circle></svg>
+
+                  <svg class="cds-ia" width="28" height="28" viewBox="-1187 1989 24 24" xmlns="http://www.w3.org/2000/svg"><title>Alert</title><desc>A red exclamation point in a cirlce.</desc><circle class="svg-stroke-hover" stroke="#FB4D42" stroke-width="3" fill="#FFF" fill-rule="evenodd" cx="-1175" cy="2001" r="10.5"></circle><path d="M-1175 2008.2c-.4 0-.8-.1-1.1-.4-.3-.3-.4-.6-.4-1s.1-.8.4-1c.3-.3.6-.4 1.1-.4.4 0 .8.1 1 .4.2.3.4.6.4 1s-.1.8-.4 1c-.3.2-.6.4-1 .4zm-1.4-14.4h2.8v2.6l-.6 7.2h-1.6l-.6-7.2v-2.6z" class="svg-fill-hover" fill="#FB4D42" fill-rule="evenodd"></path></svg>
+
+        
+      </div>
+
+      <div class="cds-c">
+
+        <div class="cds-t t--upper t--sans m-b300">
+          Meal sites for youth
+        </div>
+
+        <div class="cds-d t--subinfo">
+              <div class="field field-name-field-message field-type-text-long field-label-hidden field-items">
+                <div>
+        <p>With Boston Public Schools closed, the City is&nbsp;providing free breakfast and lunch meals, Monday through Friday, across the City.</p>
+
+            </div>
+          </div>
+
+        </div>
+
+      </div>
+
+          </a>
+    
+  </div>
+
+
+      
+  
+                    
+
+  <div class="entity entity-paragraphs-item component-section paragraphs-item-message-for-the-day motd-410691 cds g--24" bos_context_type="Message For The Day">
+
+    
+      <a href="https://www.boston.gov/news/licensing-board-advisory-bars-restaurants-and-clubs" class="cds-l d-b m-b500">
+
+    
+      <div class="cds-ic m-b500--l">
+
+        <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 66 66"><title>kitchen</title><circle cx="33" cy="33" r="31.42" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></circle><path d="M26.43,10.84c0,1.46-2,1.46-2,2.91s2,1.46,2,2.91-2,1.45-2,2.91,2,1.46,2,2.91-2,1.46-2,2.92" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></path><path d="M34,10.84c0,1.46-2,1.46-2,2.91s2,1.46,2,2.91-2,1.45-2,2.91,2,1.46,2,2.91-2,1.46-2,2.92" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></path><path d="M41.51,10.84c0,1.46-2,1.46-2,2.91s2,1.46,2,2.91-2,1.45-2,2.91,2,1.46,2,2.91-2,1.46-2,2.92" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></path><rect x="21.71" y="38.37" width="21.55" height="15.03" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></rect><path d="M43,35c-.55-3.2-5.11-5.7-10.66-5.7S22.25,31.76,21.71,35Z" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></path><line x1="32.33" y1="27.1" x2="32.33" y2="28.91" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><line x1="16.45" y1="38.44" x2="47.29" y2="38.44" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line></svg>
+
+                  <svg class="cds-ia" width="28" height="28" viewBox="-1187 1989 24 24" xmlns="http://www.w3.org/2000/svg"><title>Alert</title><desc>A red exclamation point in a cirlce.</desc><circle class="svg-stroke-hover" stroke="#FB4D42" stroke-width="3" fill="#FFF" fill-rule="evenodd" cx="-1175" cy="2001" r="10.5"></circle><path d="M-1175 2008.2c-.4 0-.8-.1-1.1-.4-.3-.3-.4-.6-.4-1s.1-.8.4-1c.3-.3.6-.4 1.1-.4.4 0 .8.1 1 .4.2.3.4.6.4 1s-.1.8-.4 1c-.3.2-.6.4-1 .4zm-1.4-14.4h2.8v2.6l-.6 7.2h-1.6l-.6-7.2v-2.6z" class="svg-fill-hover" fill="#FB4D42" fill-rule="evenodd"></path></svg>
+
+        
+      </div>
+
+      <div class="cds-c">
+
+        <div class="cds-t t--upper t--sans m-b300">
+          Restaurants and bars
+        </div>
+
+        <div class="cds-d t--subinfo">
+              <div class="field field-name-field-message field-type-text-long field-label-hidden field-items">
+                <div>
+        <p>Governor Baker issued an&nbsp;emergency order prohibiting on-premises consumption of food or drink at bars and restaurants.</p>
+
+            </div>
+          </div>
+
+        </div>
+
+      </div>
+
+          </a>
+    
+  </div>
+
+
+      
+  
+                    
+
+  <div class="entity entity-paragraphs-item component-section paragraphs-item-message-for-the-day motd-410676 cds g--24" bos_context_type="Message For The Day">
+
+    
+      <a href="https://www.boston.gov/news/temporary-guidance-construction-city-boston" class="cds-l d-b m-b500">
+
+    
+      <div class="cds-ic m-b500--l">
+
+        <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 66 66"><title>closed_roads</title><circle cx="33" cy="33" r="31.42" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></circle><line x1="20.28" y1="26.58" x2="18.28" y2="49.92" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><line x1="46.53" y1="26.58" x2="48.53" y2="49.92" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><rect x="13.53" y="20.17" width="39.25" height="5.65" fill="#fff" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></rect><rect x="13.53" y="30.9" width="39.25" height="5.65" fill="#fff" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></rect><line x1="20.28" y1="43" x2="46.53" y2="43" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><line x1="19.91" y1="20.52" x2="16.28" y2="25.47" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><line x1="25.88" y1="20.52" x2="22.26" y2="25.47" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><line x1="31.86" y1="20.52" x2="28.23" y2="25.47" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><line x1="37.83" y1="20.52" x2="34.2" y2="25.47" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><line x1="43.8" y1="20.52" x2="40.18" y2="25.47" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><line x1="49.78" y1="20.52" x2="46.15" y2="25.47" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><line x1="19.91" y1="31.25" x2="16.28" y2="36.2" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><line x1="25.88" y1="31.25" x2="22.26" y2="36.2" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><line x1="31.86" y1="31.25" x2="28.23" y2="36.2" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><line x1="37.83" y1="31.25" x2="34.2" y2="36.2" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><line x1="43.8" y1="31.25" x2="40.18" y2="36.2" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line><line x1="49.78" y1="31.25" x2="46.15" y2="36.2" fill="none" stroke="#091f2f" stroke-miterlimit="10" stroke-width="3"></line></svg>
+
+                  <svg class="cds-ia" width="28" height="28" viewBox="-1187 1989 24 24" xmlns="http://www.w3.org/2000/svg"><title>Alert</title><desc>A red exclamation point in a cirlce.</desc><circle class="svg-stroke-hover" stroke="#FB4D42" stroke-width="3" fill="#FFF" fill-rule="evenodd" cx="-1175" cy="2001" r="10.5"></circle><path d="M-1175 2008.2c-.4 0-.8-.1-1.1-.4-.3-.3-.4-.6-.4-1s.1-.8.4-1c.3-.3.6-.4 1.1-.4.4 0 .8.1 1 .4.2.3.4.6.4 1s-.1.8-.4 1c-.3.2-.6.4-1 .4zm-1.4-14.4h2.8v2.6l-.6 7.2h-1.6l-.6-7.2v-2.6z" class="svg-fill-hover" fill="#FB4D42" fill-rule="evenodd"></path></svg>
+
+        
+      </div>
+
+      <div class="cds-c">
+
+        <div class="cds-t t--upper t--sans m-b300">
+          City construction
+        </div>
+
+        <div class="cds-d t--subinfo">
+              <div class="field field-name-field-message field-type-text-long field-label-hidden field-items">
+                <div>
+        <p>Mayor Walsh has&nbsp;suspended all non-essential construction for City of Boston permitted sites.</p>
+
+            </div>
+          </div>
+
+        </div>
+
+      </div>
+
+          </a>
+    
+  </div>
+
+
+      
+  
+        </div>
+      </div>
+    </div>
+
+  
+</div>
+
+
+
+  </div>
+
+</div>
+
+                            <a></a>
+                <div class="entity entity-paragraphs-item component-section paragraphs-item-transaction-grid b b--g b--fw" bos_context_type="Transaction Grid">
+  <div class="b-c">
+
+    <div class="sh cl">
+
+      
+
+      
+    <h2 class="sh-title">Common resources</h2>
+
+
+                
+	    
+    </div>
+    <div class="g">
+                    <a href="https://www.boston.gov/career-center" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="166294">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>search</title><circle cx="74.26" cy="72.14" r="48.55" fill="#fff"></circle><circle cx="73.89" cy="72" r="50.5" fill="none" stroke="#010101" stroke-miterlimit="10" stroke-width="3"></circle><circle cx="73.89" cy="72" r="43.5" fill="none" stroke="#010101" stroke-miterlimit="10" stroke-width="3"></circle><line x1="51.38" y1="94.3" x2="71.33" y2="74.34" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></line><circle cx="81.07" cy="64.13" r="14.43" fill="#fff" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></circle></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Apply for a City job
+    </span>
+</a>
+
+
+
+      <a href="https://www.boston.gov/boston-permits-and-licenses" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="165901">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>building_permit</title><path d="M22.58,27.33v75h-11v1.27a13.18,13.18,0,0,0,12.84,13.07l94.77-.06A12.86,12.86,0,0,0,132.24,104l.18-76.64Zm1.94,86.39a10.16,10.16,0,0,1-9.75-8.63l91.5,0a12.7,12.7,0,0,0,4.49,8.56ZM129.3,104a9.7,9.7,0,0,1-9.86,9.69c-5.84,0-9.86-4.23-9.86-10v-1.48l-84,0V30.33H129.46Z" fill="#0f1f2d"></path><path d="M110.76,113.67l-86.24,0a10.16,10.16,0,0,1-9.75-8.63l91.5,0A12.7,12.7,0,0,0,110.76,113.67Z" fill="#fff"></path><path d="M129.46,30.33,129.3,104a9.71,9.71,0,0,1-9.86,9.7c-5.84,0-9.86-4.24-9.86-10v-1.48l-84,0V30.33Z" fill="#fff"></path><rect x="72.22" y="41.01" width="46.26" height="2.95" fill="#0f1f2d"></rect><rect x="72.22" y="52.82" width="46.26" height="2.95" fill="#0f1f2d"></rect><rect x="72.22" y="64.63" width="46.26" height="2.95" fill="#0f1f2d"></rect><rect x="72.22" y="76.44" width="46.26" height="2.95" fill="#0f1f2d"></rect><rect x="72.22" y="88.25" width="46.26" height="2.95" fill="#0f1f2d"></rect><rect x="33.78" y="52.11" width="30.25" height="34.87" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></rect><polygon points="31.29 58.14 66.61 58.14 63.87 48.67 34.02 48.67 31.29 58.14" fill="#fff" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polygon><rect x="52.84" y="45.23" width="5.17" height="6.89" fill="#fff" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></rect><rect x="38.15" y="73.63" width="9.04" height="13.34" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></rect><rect x="38.58" y="61.58" width="8.18" height="8.18" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></rect><rect x="51.49" y="61.58" width="8.18" height="8.18" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></rect><rect x="51.49" y="73.63" width="8.18" height="8.18" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></rect></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Building permits and licenses
+    </span>
+</a>
+
+
+
+      <a href="http://www.cityofboston.gov/assessing/search/" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="166112">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>house_2</title><rect x="19.5" y="39.5" width="105" height="81" fill="#fff" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></rect><polygon points="13.5 53.5 130.5 53.5 121.43 31.5 22.57 31.5 13.5 53.5" fill="#fff" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3" fill-rule="evenodd"></polygon><rect x="98.5" y="23.5" width="12" height="16" fill="#fff" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="32.5" y="89.5" width="21" height="31" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="93.5" y="90.5" width="19" height="19" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="98.5" y="95.5" width="9" height="9" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="63.5" y="90.5" width="19" height="19" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="68.5" y="95.5" width="9" height="9" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="93.5" y="60.5" width="19" height="19" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="98.5" y="65.5" width="9" height="9" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="63.5" y="60.5" width="19" height="19" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="68.5" y="65.5" width="9" height="9" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="33.5" y="60.5" width="19" height="19" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="38.5" y="65.5" width="9" height="9" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></rect></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        City property information search
+    </span>
+</a>
+
+
+
+      <a href="https://2020census.gov/" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="166024">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>family</title><polygon points="61.78 58.22 46.13 58.22 34.99 66.64 34.99 95.54 72.83 95.54 72.83 66.96 61.78 58.22" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polygon><circle cx="53.58" cy="41.1" r="10.04" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></circle><polygon points="114.47 58.22 98.81 58.22 87.68 66.64 87.68 95.54 125.52 95.54 125.52 66.96 114.47 58.22" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polygon><circle cx="106.26" cy="41.1" r="10.04" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></circle><polygon points="85.03 67.77 73.36 67.77 65.07 74.04 65.07 95.58 93.27 95.58 93.27 74.28 85.03 67.77" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polygon><circle cx="78.92" cy="55.01" r="7.49" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></circle><circle cx="50.87" cy="100.43" r="12.51" fill="#fff" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></circle><polyline points="56.88 95.24 47.47 104.65 43.37 100.93" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polyline><circle cx="80.18" cy="100.43" r="12.51" fill="#fff" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></circle><polyline points="86.19 95.24 76.78 104.65 72.67 100.93" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polyline><circle cx="109.31" cy="100.43" r="12.51" fill="#fff" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></circle><polyline points="115.32 95.24 105.91 104.65 101.8 100.93" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polyline></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Complete the 2020 federal census
+    </span>
+</a>
+
+
+
+      <a href="https://www.boston.gov/departments/parking-clerk/how-get-resident-parking-permit" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="166210">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>parking_pass</title><rect x="6.5" y="30.13" width="131" height="87" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="11.5" y="35.13" width="121" height="77" fill="none" stroke="#0f1f2d" stroke-miterlimit="10"></rect><rect x="11.5" y="35.13" width="121" height="77" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><path d="M32.16,55.19c0,1.07-.81,2.25-1.92,3.45l-2.73,2.9h5.13v1.59H25.17V61.84l3.88-4.16a3.86,3.86,0,0,0,1.27-2.23c0-.84-.66-1.35-1.75-1.35a4.56,4.56,0,0,0-2.87,1.32L25,54.05a6.11,6.11,0,0,1,3.82-1.5C30.8,52.55,32.16,53.59,32.16,55.19Z" fill="#002a3d"></path><path d="M43,57.88c0,3.4-1.59,5.29-4.45,5.29S34,61.28,34,57.88s1.59-5.3,4.47-5.3S43,54.47,43,57.88Zm-7.11,0c0,2.65.89,3.9,2.66,3.9s2.64-1.25,2.64-3.9S40.26,54,38.51,54,35.85,55.21,35.85,57.88Z" fill="#002a3d"></path><path d="M45.93,63.13V54.2h-2V52.63H47.7v10.5Z" fill="#002a3d"></path><path d="M57.87,53.35l-.69,1.33A4.44,4.44,0,0,0,54.86,54c-2,0-3,1.53-2.93,3.8a3.08,3.08,0,0,1,2.87-1.49,3.12,3.12,0,0,1,3.37,3.35,3.37,3.37,0,0,1-3.69,3.52c-2.65,0-4.27-1.89-4.27-5.11s1.75-5.54,4.53-5.54A6.92,6.92,0,0,1,57.87,53.35Zm-5.65,6.37a2,2,0,0,0,2.17,2,1.92,1.92,0,0,0,2.13-2,1.84,1.84,0,0,0-2.05-1.93A2,2,0,0,0,52.22,59.72Z" fill="#002a3d"></path><path d="M28.85,95.63V77.77H24.72V73.2h9.83V95.63Z" fill="#002a3d"></path><path d="M58.83,84.39c0,7.33-3.55,11.4-9.88,11.4s-10-4.07-10-11.4S42.55,73,49,73,58.83,77.1,58.83,84.39Zm-14,0c0,5.12,1.22,7.24,4.1,7.24S53,89.51,53,84.39,51.76,77.2,49,77.2,44.85,79.28,44.85,84.39Z" fill="#002a3d"></path><rect x="76.5" y="50.13" width="44" height="3" fill="#111f2d"></rect><rect x="76.5" y="56.13" width="44" height="3" fill="#111f2d"></rect><rect x="76.5" y="62.13" width="44" height="3" fill="#111f2d"></rect><rect x="76.5" y="68.13" width="44" height="3" fill="#111f2d"></rect><path d="M79.43,91.78c0,.17,0,.34,0,.49a1.7,1.7,0,0,1-.05.41l1.09-.05,0,.56H77.19v-.42a1.55,1.55,0,0,0,.57-.12.88.88,0,0,0,.36-.3,1.5,1.5,0,0,0,.21-.46,2.67,2.67,0,0,0,.07-.6l.29-6.14h0l-1.58,1-.24-.38,2.54-1.88h.44Z" fill="#002a3d"></path><path d="M81.84,85.84a1.43,1.43,0,0,1,.18-.66,2.15,2.15,0,0,1,.55-.63,2.8,2.8,0,0,1,.89-.48,3.44,3.44,0,0,1,1.2-.19,4.35,4.35,0,0,1,1,.11,2.45,2.45,0,0,1,.82.37A2,2,0,0,1,87,85a2.26,2.26,0,0,1,.21,1,2.54,2.54,0,0,1-.12.74,3,3,0,0,1-.43.84,6.54,6.54,0,0,1-.82,1,12.62,12.62,0,0,1-1.31,1.13A11.67,11.67,0,0,0,83,91.06a2.57,2.57,0,0,0-.72,1.18l3,.08a5.09,5.09,0,0,0,.58,0,1.47,1.47,0,0,0,.46-.13.89.89,0,0,0,.3-.28,1.06,1.06,0,0,0,.12-.48h.4L87,93.19H81.41A3.26,3.26,0,0,1,81.68,92a4,4,0,0,1,.63-1,6.56,6.56,0,0,1,.87-.88l1-.88a7.71,7.71,0,0,0,.75-.77,6.35,6.35,0,0,0,.57-.77,3.94,3.94,0,0,0,.35-.76,2.35,2.35,0,0,0,.12-.71,2.64,2.64,0,0,0-.08-.7,1.46,1.46,0,0,0-.26-.58,1.23,1.23,0,0,0-.47-.4,1.76,1.76,0,0,0-.73-.14,1.81,1.81,0,0,0-.52.07,1.67,1.67,0,0,0-.45.2,1.28,1.28,0,0,0-.36.29,1.56,1.56,0,0,0-.24.35.67.67,0,0,1,.17.29,1.7,1.7,0,0,1,0,.28.64.64,0,0,1,0,.23.62.62,0,0,1-.12.19.5.5,0,0,1-.19.13.54.54,0,0,1-.25.06.6.6,0,0,1-.62-.65Z" fill="#002a3d"></path><path d="M89.33,92a.83.83,0,0,0,.21.38,1.19,1.19,0,0,0,.36.26,1.77,1.77,0,0,0,.46.15,2.24,2.24,0,0,0,.52,0,2.52,2.52,0,0,0,.89-.15,1.82,1.82,0,0,0,.67-.44,2,2,0,0,0,.43-.7,2.69,2.69,0,0,0,.15-.92c0-.13,0-.26,0-.41a2.16,2.16,0,0,0-.1-.44,2.35,2.35,0,0,0-.19-.43,1.53,1.53,0,0,0-.81-.6,2.19,2.19,0,0,0-.66-.09h-.46l-.4,0,0-.58h.53a2,2,0,0,0,.68-.11,1.76,1.76,0,0,0,.51-.27,1.57,1.57,0,0,0,.35-.38,2.26,2.26,0,0,0,.22-.44,1.93,1.93,0,0,0,.12-.44,3.22,3.22,0,0,0,0-.39,2.86,2.86,0,0,0-.08-.67,1.26,1.26,0,0,0-.25-.52,1.11,1.11,0,0,0-.46-.36,1.89,1.89,0,0,0-.73-.12,1.79,1.79,0,0,0-.57.09,2.14,2.14,0,0,0-.48.23,1.55,1.55,0,0,0-.35.32.9.9,0,0,0-.19.34.55.55,0,0,1,.13.25.81.81,0,0,1,0,.25.65.65,0,0,1,0,.21.55.55,0,0,1-.3.3.59.59,0,0,1-.23,0,.55.55,0,0,1-.4-.15.61.61,0,0,1-.17-.45A1.38,1.38,0,0,1,89,85.2a2.23,2.23,0,0,1,.53-.64,3.28,3.28,0,0,1,.87-.48,3.33,3.33,0,0,1,1.19-.2,4.35,4.35,0,0,1,1,.11,2.35,2.35,0,0,1,.8.37,1.69,1.69,0,0,1,.56.65A2.29,2.29,0,0,1,94,86.65a2.14,2.14,0,0,1-.38.67,2.86,2.86,0,0,1-.69.58,3.4,3.4,0,0,1-1,.41,3.37,3.37,0,0,1,1,.24,2.25,2.25,0,0,1,.76.48,1.89,1.89,0,0,1,.47.68,2,2,0,0,1,.16.82,2.86,2.86,0,0,1-.13.85,2.81,2.81,0,0,1-.37.71,2.71,2.71,0,0,1-.55.57,3.77,3.77,0,0,1-.7.41,4.17,4.17,0,0,1-.78.25,3.83,3.83,0,0,1-.83.08,3.72,3.72,0,0,1-1.17-.16,2.75,2.75,0,0,1-.84-.42,1.8,1.8,0,0,1-.5-.58,1.33,1.33,0,0,1-.16-.62.73.73,0,0,1,.18-.52.57.57,0,0,1,.46-.2.47.47,0,0,1,.24,0,.46.46,0,0,1,.18.13.44.44,0,0,1,.12.18.54.54,0,0,1,0,.22,1.22,1.22,0,0,1,0,.26A.6.6,0,0,1,89.33,92Z" fill="#002a3d"></path><path d="M96.63,91.78l-.11.28-.09.22a1.86,1.86,0,0,0-.1.2c0,.06-.07.13-.1.2l1-.05v.56H94.79l0-.42a1,1,0,0,0,.43-.12,1.13,1.13,0,0,0,.35-.34,3,3,0,0,0,.31-.51c.09-.2.19-.42.29-.66l2.93-7.3h.29l2.48,7.41c0,.09.06.18.09.3l.09.35c0,.12.05.24.07.36a1.84,1.84,0,0,1,0,.33v.09l.84-.05v.56h-2.85v-.42a1.33,1.33,0,0,0,.39-.06.69.69,0,0,0,.24-.14.57.57,0,0,0,.13-.21,1,1,0,0,0,0-.25,1.69,1.69,0,0,0,0-.3c0-.1-.05-.19-.08-.28l-.37-1.22-3.33.08Zm1.77-4.67c-.23.57-.42,1.07-.59,1.52s-.32.84-.45,1.2h3L99,85.65h0Z" fill="#002a3d"></path><path d="M105,85.64c0-.24,0-.45,0-.61s0-.31.06-.42l-.95.06,0-.58h2.9a6.29,6.29,0,0,1,1.29.12,2.81,2.81,0,0,1,1,.37,1.77,1.77,0,0,1,.59.63,2,2,0,0,1,.2.91,2.09,2.09,0,0,1-.12.69,2.44,2.44,0,0,1-.39.65,2.52,2.52,0,0,1-.69.53,3.16,3.16,0,0,1-1,.34v0a4.25,4.25,0,0,1,1.2.16,2.54,2.54,0,0,1,.85.45,2,2,0,0,1,.5.69,2.25,2.25,0,0,1,.16.87,2.57,2.57,0,0,1-.24,1.13,2.2,2.2,0,0,1-.66.85,2.9,2.9,0,0,1-1,.53,4.26,4.26,0,0,1-1.26.18H103.7l0-.43a1.14,1.14,0,0,0,.55-.13.74.74,0,0,0,.28-.35,1.49,1.49,0,0,0,.11-.52c0-.2,0-.42,0-.67Zm.67,7h1.38a3.23,3.23,0,0,0,1-.13,2,2,0,0,0,.74-.4,1.83,1.83,0,0,0,.48-.67,2.38,2.38,0,0,0,.16-.93,2,2,0,0,0-.17-.88,1.56,1.56,0,0,0-.46-.58,1.81,1.81,0,0,0-.69-.31,3,3,0,0,0-.81-.1h-.71l-.63,0-.16,2.92c0,.24,0,.44,0,.61A2.18,2.18,0,0,1,105.68,92.66Zm1.45-8.12a1.81,1.81,0,0,0-.52.06.55.55,0,0,0-.3.21,1,1,0,0,0-.16.39c0,.16-.05.36-.07.6L106,88.22h.48l.46,0a2.44,2.44,0,0,0,1-.21,1.87,1.87,0,0,0,.64-.47,1.78,1.78,0,0,0,.35-.65,2.27,2.27,0,0,0,.11-.73,1.62,1.62,0,0,0-.17-.81,1.28,1.28,0,0,0-.44-.48,1.53,1.53,0,0,0-.59-.24A3.63,3.63,0,0,0,107.13,84.54Z" fill="#002a3d"></path><path d="M119.74,91.54a4.85,4.85,0,0,1-.94.93,5,5,0,0,1-1,.57,4.07,4.07,0,0,1-1,.28,4.54,4.54,0,0,1-.87.08,4.26,4.26,0,0,1-1.7-.33,3.91,3.91,0,0,1-1.3-.91,4.2,4.2,0,0,1-.82-1.37,5,5,0,0,1-.29-1.71,6.15,6.15,0,0,1,.13-1.27,6,6,0,0,1,.39-1.2,5.38,5.38,0,0,1,.66-1.08,4.38,4.38,0,0,1,2.1-1.44,4.73,4.73,0,0,1,1.44-.21,4.86,4.86,0,0,1,1.36.19,4.46,4.46,0,0,1,1.2.59h0l0-.7h.71l-.16,3h-.47a3.29,3.29,0,0,0-.23-1.08,2.26,2.26,0,0,0-.52-.8,2.21,2.21,0,0,0-.8-.5,2.77,2.77,0,0,0-1-.17,3,3,0,0,0-1.36.31,3.6,3.6,0,0,0-1.13.9,4.48,4.48,0,0,0-.77,1.42,5.6,5.6,0,0,0-.28,1.84,4.66,4.66,0,0,0,.25,1.57,3.66,3.66,0,0,0,.68,1.21,3.31,3.31,0,0,0,1,.78,3.11,3.11,0,0,0,1.29.27,4.09,4.09,0,0,0,.85-.09,3.94,3.94,0,0,0,.82-.27,4.52,4.52,0,0,0,.76-.46,3.47,3.47,0,0,0,.64-.63Z" fill="#002a3d"></path></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Get a resident parking permit
+    </span>
+</a>
+
+
+
+      <a href="https://www.boston.gov/departments/neighborhood-development/metrolist" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="166385">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>triple_decker</title><polygon points="107.49 32.26 36.51 32.26 35.46 26.79 108.54 26.79 107.49 32.26" fill="#fff" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polygon><rect x="39.09" y="32.44" width="66.83" height="84.77" fill="#fff" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></rect><rect x="86.24" y="40.58" width="10.6" height="10.67" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></rect><rect x="86.24" y="65.49" width="10.6" height="10.67" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></rect><rect x="86.24" y="91.4" width="10.6" height="10.67" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></rect><rect x="53.01" y="74.49" width="21.54" height="15.33" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></rect><rect x="53.01" y="47.99" width="21.54" height="15.33" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></rect><rect x="39.09" y="111.82" width="66.83" height="5.38" fill="#fff" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="47.4" y="32.67" width="5.61" height="83.87" fill="#fff" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></rect><rect x="53.01" y="101.49" width="21.54" height="15.33" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></rect><line x1="57.51" y1="101.32" x2="57.51" y2="111.32" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></line><line x1="62.51" y1="101.32" x2="62.51" y2="111.32" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></line><line x1="67.51" y1="101.32" x2="67.51" y2="111.32" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></line><line x1="53.01" y1="84.82" x2="77.01" y2="84.82" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line><line x1="53.01" y1="58.82" x2="77.01" y2="58.82" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line><rect x="71.84" y="32.67" width="5.41" height="83.87" fill="#fff" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></rect><line x1="57.51" y1="48.32" x2="57.51" y2="58.32" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line><line x1="62.51" y1="48.32" x2="62.51" y2="58.32" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line><rect x="47.4" y="32.36" width="29.86" height="5.15" fill="#fff" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></rect><line x1="67.51" y1="48.32" x2="67.51" y2="58.32" fill="none" stroke="#111f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line><line x1="57.51" y1="74.32" x2="57.51" y2="84.32" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></line><line x1="62.51" y1="74.32" x2="62.51" y2="84.32" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></line><line x1="67.51" y1="74.32" x2="67.51" y2="84.32" fill="none" stroke="#111f2d" stroke-miterlimit="10" stroke-width="3"></line></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Find affordable housing
+    </span>
+</a>
+
+
+
+      <a href="https://registry.boston.gov/birth" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="165883">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>birth_certifcate</title><rect x="12.15" y="28.06" width="119.69" height="87.88" fill="#fff"></rect><path d="M133.35,117.44H10.65V26.56h122.7Zm-119.7-3h116.7V29.56H13.65Z" fill="#0d202e"></path><rect x="66.42" y="47.06" width="47" height="3" fill="#0d202e"></rect><rect x="66.42" y="59.06" width="47" height="3" fill="#0d202e"></rect><rect x="66.42" y="71.06" width="47" height="3" fill="#0d202e"></rect><rect x="66.42" y="83.06" width="47" height="3" fill="#0d202e"></rect><rect x="66.42" y="95.06" width="47" height="3" fill="#0d202e"></rect><path d="M51.52,92.1a20.5,20.5,0,0,0-1.74-5.31,10.81,10.81,0,0,0-1.05-2c-.35-.49-.78-.92-1.17-1.37-4.13-4.73-5-12.78-.72-17.71,1.71-2,1.58-7.24,0-9.17a7.1,7.1,0,0,0-3.22-2.07,16.9,16.9,0,0,0-12.89.59,6.12,6.12,0,0,0-4,5.42c-1.47,13.07,5.29,41.42,17.64,41.42,3,0,5.44-2.24,6.54-4.93A9.15,9.15,0,0,0,51.52,92.1Z" fill="#0f1f2d"></path><ellipse cx="49.58" cy="49.1" rx="4.43" ry="3.21" transform="translate(-18.94 62.28) rotate(-55.61)" fill="#0f1f2d"></ellipse><ellipse cx="42.42" cy="47.62" rx="2.84" ry="2.05" transform="translate(-16.79 71.32) rotate(-70.12)" fill="#0f1f2d"></ellipse><ellipse cx="36.69" cy="47.54" rx="2.84" ry="2.05" transform="translate(-15.79 76.73) rotate(-81.42)" fill="#0f1f2d"></ellipse><ellipse cx="30.96" cy="48.96" rx="2.05" ry="2.84" transform="translate(-10.68 8.69) rotate(-13.65)" fill="#0f1f2d"></ellipse><ellipse cx="26.27" cy="52.95" rx="1.88" ry="2.6" transform="translate(-18.18 13.99) rotate(-22.38)" fill="#0f1f2d"></ellipse></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Order birth certificates online
+    </span>
+</a>
+
+
+
+      <a href="https://www.boston.gov/departments/parking-clerk/how-pay-parking-ticket" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="166192">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>no_ticket</title><rect x="20.5" y="12.31" width="63" height="104" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></rect><rect x="31.02" y="83.76" width="40.98" height="10.59" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2.95"></rect><rect x="31.02" y="73.26" width="40.98" height="10.59" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2.95"></rect><rect x="31.02" y="94.26" width="40.98" height="10.59" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2.95"></rect><rect x="31.02" y="52.22" width="40.98" height="10.59" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2.95"></rect><rect x="31.02" y="41.72" width="40.98" height="10.59" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2.95"></rect><rect x="31.02" y="62.72" width="40.98" height="10.59" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2.95"></rect><rect x="50.5" y="73.31" width="3" height="32" fill="#0f1f2d"></rect><circle cx="84" cy="107.34" r="24.35" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></circle><line x1="75.59" y1="98.93" x2="92.41" y2="115.75" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line><line x1="75.59" y1="115.75" x2="92.41" y2="98.93" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line><rect x="30" y="21.6" width="3" height="13" fill="#111f2d"></rect><rect x="41.57" y="21.6" width="3" height="13" fill="#111f2d"></rect><rect x="53.14" y="21.6" width="3" height="13" fill="#111f2d"></rect><rect x="64.71" y="21.6" width="3" height="13" fill="#111f2d"></rect><rect x="70.5" y="21.6" width="3" height="13" fill="#111f2d"></rect><rect x="58.93" y="21.6" width="3" height="13" fill="#111f2d"></rect><rect x="47.36" y="21.6" width="3" height="13" fill="#111f2d"></rect><rect x="35.79" y="21.6" width="3" height="13" fill="#111f2d"></rect></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Pay a parking ticket
+    </span>
+</a>
+
+
+
+      <a href="https://www.boston.gov/departments/public-works/how-pay-fine-code-violation" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="166255">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>property_violations</title><polygon points="76.82 66.45 76.82 34.28 43.79 34.28 43.79 28.76 32.76 28.76 32.76 34.28 23.72 34.28 23.72 114.26 46.82 114.26 76.82 114.26 99.92 114.26 99.92 66.45 76.82 66.45" fill="#fff" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"></polygon><rect x="32.75" y="94.27" width="11.03" height="11.03" fill="#fff" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"></rect><rect x="57.23" y="94.27" width="11.03" height="11.03" fill="#fff" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"></rect><rect x="81.71" y="94.27" width="11.03" height="11.03" fill="#fff" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"></rect><rect x="32.75" y="77.6" width="11.03" height="11.03" fill="#fff" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"></rect><rect x="57.23" y="77.6" width="11.03" height="11.03" fill="#fff" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"></rect><rect x="81.71" y="77.6" width="11.03" height="11.03" fill="#fff" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"></rect><rect x="32.75" y="60.93" width="11.03" height="11.03" fill="#fff" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"></rect><rect x="57.23" y="60.93" width="11.03" height="11.03" fill="#fff" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"></rect><rect x="32.75" y="44.27" width="11.03" height="11.03" fill="#fff" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"></rect><rect x="57.23" y="44.27" width="11.03" height="11.03" fill="#fff" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"></rect><circle cx="99.92" cy="94.87" r="20.36" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></circle><text transform="translate(96 104.54)" font-size="29.05" fill="#111f2d" font-family="Montserrat-Bold, Montserrat" font-weight="700">!</text></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Pay code violation fines
+    </span>
+</a>
+
+
+
+      <a href="https://www.invoicecloud.com/portal/(S(2ggore0qtc51ecyq3bjb3ybo))/2/Site.aspx?G=13377843-58b1-429b-be78-ab0ebba80835" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="165919">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>car_payment</title><circle cx="118.05" cy="48.43" r="15.42" fill="#fff"></circle><path d="M118.05,65.1a16.66,16.66,0,1,1,11.79-4.88A16.54,16.54,0,0,1,118.05,65.1Zm0-30.83a14.17,14.17,0,1,0,10,4.15A14,14,0,0,0,118.05,34.27Z" fill="#111f2d"></path><path d="M119.27,54.57v2.67h-2.34V54.5a8.9,8.9,0,0,1-4.24-1.86l1.22-2.42a7.72,7.72,0,0,0,4.47,1.85c1,0,1.61-.37,1.61-1.08,0-2.19-6.54-.88-6.54-5.26,0-1.9,1.35-3.2,3.48-3.61V39.5h2.34V42a9.39,9.39,0,0,1,4,1.35l-1.18,2.45a9.22,9.22,0,0,0-4-1.29c-.82,0-1.36.3-1.36.9,0,2.14,6.54.92,6.54,5.4C123.3,53,121.58,54.3,119.27,54.57Z" fill="#0f1f2d"></path><polygon points="20.96 69.7 32.76 47.26 88.51 47.26 101.31 70.52 20.96 69.7" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3" fill-rule="evenodd"></polygon><polygon points="92.24 65.25 85.86 52.26 63.2 52.26 63.2 65.25 92.24 65.25" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polygon><polygon points="29.55 65.23 35.7 52.26 58.36 52.26 58.36 65.23 29.55 65.23" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polygon><polygon points="92.24 65.25 85.86 52.26 63.2 52.26 63.2 65.25 92.24 65.25" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3" fill-rule="evenodd"></polygon><polygon points="29.55 65.23 35.7 52.26 58.36 52.26 58.36 65.23 29.55 65.23" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3" fill-rule="evenodd"></polygon><polygon points="9.28 69.34 115.68 69.34 125.23 79.35 125.23 98.54 9.28 98.54 9.28 69.34" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3" fill-rule="evenodd"></polygon><circle cx="36.81" cy="98.89" r="13.35" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></circle><circle cx="36.81" cy="98.89" r="7.51" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></circle><circle cx="92.05" cy="98.89" r="13.35" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></circle><circle cx="92.05" cy="98.89" r="7.51" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></circle><line x1="62.16" y1="71.28" x2="62.16" y2="97.04" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line><line x1="29.05" y1="76.16" x2="36.72" y2="76.16" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line><line x1="69.09" y1="76.16" x2="76.76" y2="76.16" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Pay your motor vehicle excise tax
+    </span>
+</a>
+
+
+
+      <a href="https://www.invoicecloud.com/portal/(S(scnz1wa3impvdxtnkldze42j))/2/Site.aspx?G=13377843-58b1-429b-be78-ab0ebba80835" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="166276">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>residential_exemption</title><rect x="17.54" y="35.2" width="105" height="81" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><polygon points="11.54 49.2 128.54 49.2 119.47 27.2 20.61 27.2 11.54 49.2" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3" fill-rule="evenodd"></polygon><rect x="96.54" y="19.2" width="12" height="16" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="30.54" y="85.2" width="21" height="31" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="90.54" y="57.2" width="19" height="19" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="95.54" y="62.2" width="9" height="9" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="90.54" y="87.2" width="19" height="19" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="95.54" y="92.2" width="9" height="9" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="61.04" y="57.2" width="19" height="19" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="66.04" y="62.2" width="9" height="9" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="61.04" y="87.2" width="19" height="19" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="66.04" y="92.2" width="9" height="9" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="31.54" y="57.2" width="19" height="19" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="36.54" y="62.2" width="9" height="9" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><path d="M127.05,119.39a18.48,18.48,0,1,1,0-26.14A18.48,18.48,0,0,1,127.05,119.39Z" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></path><path d="M115.5,110.58v2.88h2.9l-2.21,3.33L114,120.12l-2.22-3.33-2.21-3.33h3.16v-3a10.67,10.67,0,0,1-5.09-2.23l1.46-2.9a9.3,9.3,0,0,0,5.36,2.22c1.19,0,1.93-.44,1.93-1.29,0-2.63-7.84-1.06-7.84-6.32,0-2.26,1.61-3.83,4.18-4.32V92.52h2.8v3a11.15,11.15,0,0,1,4.78,1.61l-1.42,2.94a11,11,0,0,0-4.74-1.55c-1,0-1.63.36-1.63,1.09,0,2.56,7.84,1.1,7.84,6.46C120.33,108.74,118.27,110.26,115.5,110.58Z" fill="#111f2d"></path></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Pay your real estate taxes
+    </span>
+</a>
+
+
+
+      <a href="https://www.cityofboston.gov/311/" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="166477">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 118 129.33"><title>bos_311_icon_black</title><g id="Layer_7" data-name="Layer 7"><rect x="11.31" y="102.88" width="95.39" height="16.55" fill="#091f2f"></rect><path d="M13.62,10.89H25.83a29.9,29.9,0,0,1,8.23.76A7.43,7.43,0,0,1,39.51,19a7.45,7.45,0,0,1-.58,3c-1.43,3.22-4.47,3.85-6.17,4.21,1.92.31,4.47.71,6.21,2.68a7,7,0,0,1,1.75,4.74,8.4,8.4,0,0,1-5.23,7.64c-2.37,1-4.92,1.17-8.54,1.17H13.62Zm7.51,5.9v6.57h5.95c1.79,0,4.7-.13,4.7-3.39,0-3-2.64-3.18-4.16-3.18Zm0,12.3v7.64h5.5c2.64,0,6.08-.13,6.08-3.75,0-3.8-3.13-3.85-4.73-3.89Z" fill="#091f2f"></path><path d="M59.63,43.35c-10,0-15.7-7.69-15.7-16.81,0-8.54,5.41-16.63,15.56-16.63a17.76,17.76,0,0,1,5.77.93c9.66,3.36,10.28,13.87,10.28,16a17.15,17.15,0,0,1-6,13.19A15.16,15.16,0,0,1,59.63,43.35ZM65.08,18.8a7.69,7.69,0,0,0-5.54-2.32c-4.79,0-7.83,4.2-7.83,9.92,0,7.52,4.21,10.29,7.92,10.29s7.78-2.68,8-9.3C67.76,24.08,66.87,20.73,65.08,18.8Z" fill="#091f2f"></path><path d="M82.74,33a9.87,9.87,0,0,0,3,2.46A13.08,13.08,0,0,0,91.86,37c3.13,0,5.81-1.48,5.81-3.67,0-2.5-3.17-2.91-5.5-3.22-1.74-.22-3.48-.45-5.18-.8-1.93-.41-8.5-1.79-8.5-8.59,0-8.13,7.24-10.55,12.7-10.55,7.29,0,11.22,3.53,14,6l-5.81,4.16a14.92,14.92,0,0,0-3.13-2.55,11.43,11.43,0,0,0-5.15-1.39c-3.13,0-4.69,1.79-4.69,3.31,0,2.42,2.68,2.78,4,3A63.06,63.06,0,0,1,100,24.48a7.83,7.83,0,0,1,5.46,7.74,10.46,10.46,0,0,1-2.51,6.7c-2.86,3.31-7.42,4.25-11.85,4.25-8.89,0-12.43-4.11-14.39-6.39Z" fill="#091f2f"></path><path d="M14.43,58.91h7.15v7.51H14.43Zm0,15.74h7.15v7.6H14.43Z" fill="#091f2f"></path><path d="M35.48,60.56c.32-2.81,1.17-5.23,3.36-7,2.59-2.1,6-2.14,7.24-2.14,3.8,0,6,1.07,7.15,2.1a7.8,7.8,0,0,1,2.73,6,6.8,6.8,0,0,1-2.28,5.28A9.56,9.56,0,0,1,51,66.29a11.45,11.45,0,0,1,1.75.49,6.69,6.69,0,0,1,4,6.44A9.29,9.29,0,0,1,54.62,79c-2.37,2.9-6,3.75-9.39,3.75a10.5,10.5,0,0,1-8.18-3.3c-2.15-2.55-2.15-5.64-2.15-7.43l7-.58c0,.45-.05.85-.05,1.3,0,2.82,1.66,4.47,3.71,4.47,2.37,0,4-1.65,4-4.47,0-4.11-3.71-3.94-5.45-3.85V63.78a7.2,7.2,0,0,0,2.23-.09,3.38,3.38,0,0,0,2.6-3.44,3.21,3.21,0,0,0-3.27-3.44c-3.08,0-3.08,3.08-3.08,4.38Z" fill="#091f2f"></path><path d="M63.16,56.45a12,12,0,0,0,5-1.12,6.33,6.33,0,0,0,3.13-3.4h5.46V82.25h-7.2V60.12c-1.66.71-2.06.89-6.39,1Z" fill="#091f2f"></path><path d="M85.47,56.45a12,12,0,0,0,5-1.12,6.33,6.33,0,0,0,3.13-3.4h5.46V82.25h-7.2V60.12c-1.66.71-2.06.89-6.39,1Z" fill="#091f2f"></path></g></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Report an issue on 311
+    </span>
+</a>
+
+
+
+  
+
+          </div>
+  </div>
+</div>
+
+                            <a></a>
+                
+ 
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+            
+            
+            
+            
+      
+      
+
+<div class="entity entity-paragraphs-item component-section paragraphs-item-featured-topics b b--fw" bos_context_type="Featured Topics">
+  <div class="clo">
+    
+  </div>
+  <div class="cdfg-oc">
+              <a href="https://www.boston.gov/winter-boston" class="cdfg cdfg--ob" style="background-image: url(https://www.boston.gov/sites/default/files/img/unk/intro_images/TOPIC-HERO-WINTER_10.jpg)">
+        <div class="cdfg-c">
+          <div class="cdfg-i">
+            <span>1</span>
+          </div>
+          <div class="cdfg-ic">
+            <div class="cdfg-d">Guide:</div>
+            <div class="cdfg-t">Winter in Boston</div>
+          </div>
+        </div>
+      </a>
+          <a href="https://www.boston.gov/trash-and-recycling" class="cdfg cdfg--cb" style="background-image: url(https://www.boston.gov/sites/default/files/img/library/photos/2016/10/dsc_0030.jpg)">
+        <div class="cdfg-c">
+          <div class="cdfg-i">
+            <span>2</span>
+          </div>
+          <div class="cdfg-ic">
+            <div class="cdfg-d">Guide:</div>
+            <div class="cdfg-t">Trash and recycling</div>
+          </div>
+        </div>
+      </a>
+          <a href="https://www.boston.gov/visiting-boston" class="cdfg cdfg--r" style="background-image: url(https://www.boston.gov/sites/default/files/img/library/photos/2018/09/dsc_0134_1.jpg)">
+        <div class="cdfg-c">
+          <div class="cdfg-i">
+            <span>3</span>
+          </div>
+          <div class="cdfg-ic">
+            <div class="cdfg-d">Guide:</div>
+            <div class="cdfg-t">Visiting Boston</div>
+          </div>
+        </div>
+      </a>
+          <a href="https://www.boston.gov/getting-around-boston" class="cdfg cdfg--cb" style="background-image: url(https://www.boston.gov/sites/default/files/img/unk/intro_images/hubway_0325.jpg)">
+        <div class="cdfg-c">
+          <div class="cdfg-i">
+            <span>4</span>
+          </div>
+          <div class="cdfg-ic">
+            <div class="cdfg-d">Guide:</div>
+            <div class="cdfg-t">Getting around Boston</div>
+          </div>
+        </div>
+      </a>
+      </div>
+
+</div>
+
+                            <a class="subnav-anchor" name="latest-news" data-text="Latest news"></a>
+                
+<div class="entity entity-paragraphs-item component-section paragraphs-item-news-and-announcements component-section" bos_context_type="News And Announcements">
+
+  <div class="content container">
+
+  	  <div class="sh cl">
+
+        
+
+                  
+    <h2 class="sh-title">Latest news</h2>
+
+        
+                  	<span class="field field-name-field-short-title field-type-text field-type-string component-short-title">
+		Latest news
+	</span>
+
+        
+        
+      </div>
+
+     <div>
+                   <article role="article" about="/news/coronavirus-disease-covid-19-boston" class="node-11561926 node clearfix node-post modstate-published desktop-100 post-featured-item-wrapper mobile-1-col" bos_context_type="Post" id="node-11561926">
+
+  <a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston" class="item-link">Coronavirus Disease (COVID-19) in Boston</a>
+
+  <div class="mobile-1-col tablet-1-col desktop-2-col thumb-column featured-item-thumb featured-post-thumb" style="height: 334.5px;">
+
+      <div class="featured-thumb-wrapper">
+
+        
+                      <article>
+                      <picture>
+                <!--[if IE 9]><video style="display: none;"><![endif]-->
+              <source srcset="/sites/default/files/styles/featured_image_a_mobile_1x/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=qjwbIBRh 1x" media="(min-width: 0px) and (max-width: 419px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/featured_image_b_tablet_1x/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=-us3Hlr3 1x" media="(min-width: 420px)  and (max-width: 767px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/featured_image_c_desktop_1/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=AcGKlPbM 1x" media="(min-width: 768px) and (max-width: 839px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/featured_image_d_full_1x/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=sKoncItS 1x" media="(min-width: 840px) and (max-width: 1439px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/featured_image_d_full_1x/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=sKoncItS 1x" media="(min-width: 1440px) and (max-width: 1919px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/featured_image_d_full_1x/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=sKoncItS 1x" media="(min-width: 1920px)" type="image/jpeg">
+            <!--[if IE 9]></video><![endif]-->
+              
+      <img src="./Boston.gov_files/city-hall-pic.jpg" alt="Image for bcyf city hall childcare" typeof="foaf:Image">
+
+  
+  </picture>
+
+
+      
+  </article>
+
+      
+
+        
+        <div class="date-flag">Apr 7</div>
+
+      </div>
+
+    </div>
+
+    <div class="mobile-1-col tablet-1-col desktop-2-col featured-item-details">
+
+      <div class="text-wrapper">
+
+        <div class="feature-header">
+          <h3 class="title">Coronavirus Disease (COVID-19) in Boston</h3>
+        <div class="department-title">            
+  <div class="di">
+  <div class="di-ic">
+    <a href="https://www.boston.gov/departments/public-health-commission" cob-title="Public Health Commission" class="di-tt">
+                  <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 137 130"><title>public_health_commission_logo</title><g id="Layer_7" data-name="Layer 7"><g id="Layer_2" data-name="Layer 2"><g id="icons"><rect x="59.17" y="79.75" width="17" height="64.43" transform="translate(-45.48 177.64) rotate(-88.98)" fill="#ff454a"></rect><path d="M69.48,9.48,37.27,9l-.76,43.28C40.18,78.5,68.12,86,68.12,86S97,77,100.93,53.39l.76-43.28Z" fill="#091f2f"></path></g></g><path d="M53.88,66.91a27.1,27.1,0,0,0,4.67,5.22,44.66,44.66,0,0,0,5.72,4.29A67,67,0,0,0,70.92,80l0,0L71,80q-2.72-5.42-2.64-9.44a8.42,8.42,0,0,1,1.1-4,13,13,0,0,1,2.74-3.37c1.12-1,2.36-2,3.72-2.95s2.72-2,4.08-3.17a35.57,35.57,0,0,0,3.73-3.62,15.39,15.39,0,0,0,2.76-4.67,17.14,17.14,0,0,0,1.14-6h0a25,25,0,0,0-1-7.73,23.27,23.27,0,0,0-2.92-6.36,27.4,27.4,0,0,0-4.67-5.22,44.66,44.66,0,0,0-5.72-4.29,67,67,0,0,0-6.65-3.59l0,0-.13,0q2.67,5.49,2.6,9.43a8.42,8.42,0,0,1-1.1,4,13,13,0,0,1-2.74,3.37c-1.12,1-2.36,2-3.72,3s-2.72,2-4.08,3.17a34.68,34.68,0,0,0-3.73,3.63,15.34,15.34,0,0,0-2.76,4.66,17.19,17.19,0,0,0-1.14,6,24.94,24.94,0,0,0,1,7.72A23.27,23.27,0,0,0,53.88,66.91Z" fill="#fff"></path></g></svg>
+  </div>
+
+
+      
+  </article>
+
+      
+
+    </a>
+  </div>
+</div>
+
+
+
+      </div>
+
+      </div>
+
+      <div class="intro-text">We will update this page as new and relevant COVID-19 information becomes available.</div>
+
+    </div>
+
+  </div>
+
+</article>
+
+      
+     </div>
+
+     <div class="clearfix">
+        
+<div class="field__item field__item-label-hidden">
+
+  
+
+  
+      <div class="views-element-container"><div class="js-view-dom-id-84f3a9ce11b7bbd599704a7e98f2b2dfbb4f01b22bcac68ba350ee40c818634d">
+  
+  
+  
+
+  
+  
+  
+
+  
+<div class="clearfix">
+      
+<div class="mobile-1-col tablet-1-col xxl-desktop-2-col clearfix news-item news-item-short-listing news-item-news">
+
+  <a href="https://www.boston.gov/news/john-jack-dempsey-appointed-boston-fire-department-commissioner" class="item-link"></a>
+
+  <div class="news-item-wrapper ">
+
+      <div class="thumb-wrapper float-left">
+
+                            
+      <img src="./Boston.gov_files/dempsey-thumb.jpg" width="190" height="190" alt="Chief John &#39;Jack&#39; Dempsey" typeof="foaf:Image">
+
+  
+  
+
+        
+        <div class="date-flag"><time datetime="2020-04-24T22:18:01Z">Apr 24</time>
+</div>
+
+      </div>
+
+      <div class="text-wrapper">
+    
+        <h3 class="title"><p>John 'Jack' Dempsey appointed Boston Fire Department commissioner</p>
+</h3>
+        <div class="department-title">Fire Operations</div>
+      </div>
+
+  </div>
+
+</div>
+
+      
+<div class="mobile-1-col tablet-1-col xxl-desktop-2-col clearfix news-item news-item-short-listing news-item-news">
+
+  <a href="https://www.boston.gov/news/universal-testing-covid-19-unhoused-individuals-boston" class="item-link"></a>
+
+  <div class="news-item-wrapper ">
+
+      <div class="thumb-wrapper float-left">
+
+                  <div class="news-item-default-image">
+            <span>Image for <p>Universal testing for COVID-19 for unhoused individuals in Boston</p>
+</span>
+          </div>
+        
+        <div class="date-flag"><time datetime="2020-04-24T22:11:26Z">Apr 24</time>
+</div>
+
+      </div>
+
+      <div class="text-wrapper">
+    
+        <h3 class="title"><p>Universal testing for COVID-19 for unhoused individuals in Boston</p>
+</h3>
+        <div class="department-title">Public Health Commission</div>
+      </div>
+
+  </div>
+
+</div>
+
+      
+<div class="mobile-1-col tablet-1-col xxl-desktop-2-col clearfix news-item news-item-short-listing news-item-news">
+
+  <a href="https://www.boston.gov/news/city-boston-allow-permitted-restaurants-sell-groceries" class="item-link"></a>
+
+  <div class="news-item-wrapper ">
+
+      <div class="thumb-wrapper float-left">
+
+                  <div class="news-item-default-image">
+            <span>Image for <p>City of Boston to allow permitted restaurants to sell groceries</p>
+</span>
+          </div>
+        
+        <div class="date-flag"><time datetime="2020-04-24T20:57:57Z">Apr 24</time>
+</div>
+
+      </div>
+
+      <div class="text-wrapper">
+    
+        <h3 class="title"><p>City of Boston to allow permitted restaurants to sell groceries</p>
+</h3>
+        <div class="department-title">Economic Development</div>
+      </div>
+
+  </div>
+
+</div>
+
+      
+<div class="mobile-1-col tablet-1-col xxl-desktop-2-col clearfix news-item news-item-short-listing news-item-news">
+
+  <a href="https://www.boston.gov/news/city-boston-recognizes-national-crime-victims-rights-week" class="item-link"></a>
+
+  <div class="news-item-wrapper ">
+
+      <div class="thumb-wrapper float-left">
+
+                  <div class="news-item-default-image">
+            <span>Image for <p>City of Boston recognizes National Crime Victims' Rights Week</p>
+</span>
+          </div>
+        
+        <div class="date-flag"><time datetime="2020-04-23T20:29:19Z">Apr 23</time>
+</div>
+
+      </div>
+
+      <div class="text-wrapper">
+    
+        <h3 class="title"><p>City of Boston recognizes National Crime Victims' Rights Week</p>
+</h3>
+        <div class="department-title">Mayor's Office</div>
+      </div>
+
+  </div>
+
+</div>
+
+  </div>
+
+    
+
+  
+  
+
+  
+  
+</div>
+</div>
+
+  
+</div>
+
+
+    </div>
+
+          <a href="https://www.boston.gov/news" class="btn">More City news</a>
+    
+  </div>
+
+</div>
+
+                            <a class="subnav-anchor" name="featured-videos" data-text="Featured videos"></a>
+                <div class="entity entity-paragraphs-item component-section paragraphs-item-grid-of-cards b--w b b--fw" bos_context_type="Grid Of Cards">
+
+  <div class="b-c">
+
+    <div class="sh">
+
+      
+
+      
+    <h2 class="sh-title">Featured videos</h2>
+
+
+      
+
+              <div class="sh-contact">
+          
+        </div>
+      
+    </div>
+
+    <div class="g">
+                          
+
+<a href="https://www.youtube.com/watch?v=8FgqH2KWXu4" class="entity entity-paragraphs-item component-section paragraphs-item-card cd g--4 g--4--sl m-t500" bos_context_type="Card" data-lity="">
+
+  <div class="cd-ic cd-ic-357546"></div>
+
+  <div class="cd-c">
+
+    <div class="cd-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>Boston, we're still here</p>
+
+            </div>
+          </div>
+</div>
+
+          <div class="cd-st t--upper t--subtitle"></div>
+    
+    <div class="cd-d">    <div class="field field-name-field-short-description field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>Boston, our workers on the frontlines are still here for you. Please stay home for them.</p>
+
+            </div>
+          </div>
+</div>
+
+  </div>
+
+</a>
+
+              
+
+<a href="https://www.youtube.com/watch?v=8y3IxYEvhT8" class="entity entity-paragraphs-item component-section paragraphs-item-card cd g--4 g--4--sl m-t500" bos_context_type="Card" data-lity="">
+
+  <div class="cd-ic cd-ic-357536"></div>
+
+  <div class="cd-c">
+
+    <div class="cd-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>A Changing City: Climate change</p>
+
+            </div>
+          </div>
+</div>
+
+          <div class="cd-st t--upper t--subtitle"></div>
+    
+    <div class="cd-d">    <div class="field field-name-field-short-description field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>Our future is defined by our actions today.</p>
+
+            </div>
+          </div>
+</div>
+
+  </div>
+
+</a>
+
+              
+
+<a href="https://www.youtube.com/user/cityofboston" class="entity entity-paragraphs-item component-section paragraphs-item-card cd g--4 g--4--sl m-t500" bos_context_type="Card">
+
+  <div class="cd-ic cd-ic-357556"></div>
+
+  <div class="cd-c">
+
+    <div class="cd-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>Watch us on YouTube</p>
+
+            </div>
+          </div>
+</div>
+
+          <div class="cd-st t--upper t--subtitle"></div>
+    
+    <div class="cd-d">    <div class="field field-name-field-short-description field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>Check out our latest videos on the City of Boston's YouTube account.</p>
+
+            </div>
+          </div>
+</div>
+
+  </div>
+
+</a>
+
+      
+          </div>
+
+  </div>
+
+</div>
+
+                            <a class="subnav-anchor" name="bos311" data-text="BOS:311"></a>
+                <div class="entity entity-paragraphs-item component-section paragraphs-item-bos311 b b--fw b--b b--by" bos_context_type="Bos311">
+
+  <div class="b-c">
+
+    <div class="sh sh--y sh--b0 m-b200 cl">
+
+      
+
+      
+    <h2 class="sh-title">BOS:311 service requests</h2>
+
+
+              	<span class="field field-name-field-short-title field-type-text field-type-string component-short-title">
+		BOS:311
+	</span>
+
+      
+    </div>
+
+    <div class="g">
+      <div class="g">
+      
+      <a href="http://www.cityofboston.gov/311/" class="g--4 g--4--sl"><div class="lwa lwa--w">All BOS:311 requests</div></a>
+
+ 
+      
+      <a href="http://www.cityofboston.gov/mayor/24?topic=trash-storage" class="g--4 g--4--sl"><div class="lwa lwa--w">Improper storage of trash barrels</div></a>
+
+ 
+      
+      <a href="http://www.cityofboston.gov/mayor/24?topic=sidewalk-snow" class="g--4 g--4--sl"><div class="lwa lwa--w">Report unshoveled sidewalk (wait until three hours after snowfall ends)</div></a>
+
+ 
+      
+      <a href="http://www.cityofboston.gov/mayor/24?topic=bulk-item-pickup" class="g--4 g--4--sl"><div class="lwa lwa--w">Request a bulk item pickup</div></a>
+
+ 
+      
+      <a href="http://www.cityofboston.gov/mayor/24?topic=generic" class="g--4 g--4--sl"><div class="lwa lwa--w">Request to salt or plow a street</div></a>
+
+ 
+      
+      <a href="http://www.cityofboston.gov/mayor/24?topic=pothole" class="g--4 g--4--sl"><div class="lwa lwa--w">Report a pothole</div></a>
+
+ 
+      
+      <a href="http://www.cityofboston.gov/mayor/24?topic=parking-enforcement" class="g--4 g--4--sl"><div class="lwa lwa--w">Report a parking violation</div></a>
+
+ 
+      
+      <a href="http://www.cityofboston.gov/mayor/24?topic=streetsign" class="g--4 g--4--sl"><div class="lwa lwa--w">Report a missing or damaged street sign</div></a>
+
+ 
+      
+      <a href="http://www.cityofboston.gov/mayor/24?topic=streetlight" class="g--4 g--4--sl"><div class="lwa lwa--w">Report a streetlight outage</div></a>
+
+ 
+  </div>
+
+    </div>
+
+  </div>
+
+</div>
+
+                            <a class="subnav-anchor" name="stay-connected" data-text="Stay Connected"></a>
+                
+<div class="entity entity-paragraphs-item component-section paragraphs-item-newsletter" bos_context_type="Newsletter">
+
+  <div class="b b--fw b--w">
+
+    <div class="b-c">
+
+      <div class="sh cl m-b300" "="">
+
+        
+
+                  
+    <h2 class="sh-title">Stay Connected</h2>
+
+        
+                  
+        
+      </div>
+
+      <div class="g">
+
+                  <div class="g--6">
+            <div class="t--intro">    <div class="field field-name-field-description field-type-text-long field-label-hidden field-items">
+                <div>
+        <p>Sign up for email updates from the City of Boston, including information on big events and upcoming traffic and parking restrictions.</p>
+
+            </div>
+          </div>
+</div>
+          </div>
+        
+        <div class="g--6">
+
+                      <form action="https://contactform.boston.gov/subscriptions?list=2" method="POST" class="bos-newsletter" novalidate="">
+
+              <div class="fs">
+
+                <div class="fs-c fs-c--i">
+
+                  <div class="txt">
+                    <label for="subscriber[email]" class="txt-l">Your Email Address</label>
+                    <input name="subscriber[email]" type="email" value="" placeholder="Email address" class="txt-f bos-newsletter-email">
+                  </div>
+
+                  <div class="txt">
+                    <label for="subscriber[zipcode]" class="txt-l">Zip Code</label>
+                    <input name="subscriber[zipcode]" type="text" value="" placeholder="Zip Code" class="txt-f bos-newsletter-zip" size="18">
+                  </div>
+
+                </div>
+
+                <div class="bc bc--r">
+                  <button type="submit" class="btn btn--700">Sign Up</button>
+                </div>
+
+              </div>
+
+            </form>
+
+          
+        </div>
+
+      </div>
+
+    </div>
+
+  </div>
+
+</div>
+
+                            <a></a>
+                
+<div class="entity entity-paragraphs-item component-section paragraphs-item-events-and-notices" bos_context_type="Events And Notices">
+
+  <div class="content container">
+
+    <div class="sh cl">
+
+      
+
+              
+    <h2 class="sh-title">Upcoming Events</h2>
+
+      
+              
+      
+      
+    </div>
+
+    <div>
+     
+    </div>
+
+    <div class="clearfix">
+       
+<div class="field__item field__item-label-hidden">
+
+  
+
+  
+      <div class="views-element-container"><div class="js-view-dom-id-e392a6adf525304d612eaa44a4e1ab4d78e8c71635ee0ab5bd1f620b823024d1">
+  
+  
+  
+
+  
+  
+  
+
+  
+<div class="grid-wrapper clearfix">
+      
+<div class="mobile-1-col tablet-1-col xxl-desktop-2-col clearfix news-item news-item-short-listing news-item-event">
+  <a href="https://www.boston.gov/calendar/winter-fitness-series-walking-group-snowshoeing" class="item-link"></a>
+  <div class="news-item-wrapper">
+
+    <div class="thumb-wrapper float-left">
+
+                        
+      <img src="./Boston.gov_files/winter-fitness-hero-image.png" width="190" height="190" alt="Boston Parks Winter Fitness series" typeof="foaf:Image">
+
+  
+  
+
+      
+      <div class="date-flag">
+        Apr 26
+      </div>
+
+    </div>
+
+    <div class="text-wrapper">
+      <h3 class="title">
+        <span class="red">CANCELED: </span>Winter Fitness series: Walking group / snowshoeing
+
+      </h3>
+    </div>
+
+  </div>
+</div>
+
+      
+<div class="mobile-1-col tablet-1-col xxl-desktop-2-col clearfix news-item news-item-short-listing news-item-event">
+  <a href="https://www.boston.gov/calendar/leaf-and-yard-waste-drop-0" class="item-link"></a>
+  <div class="news-item-wrapper">
+
+    <div class="thumb-wrapper float-left">
+
+                        
+      <img src="./Boston.gov_files/yard-waste-banner.jpg" width="190" height="190" alt="Image for leaf and yard waste drop off" typeof="foaf:Image">
+
+  
+  
+
+      
+      <div class="date-flag">
+        Apr 26
+      </div>
+
+    </div>
+
+    <div class="text-wrapper">
+      <h3 class="title">
+        <span class="red">CANCELED: </span>Leaf and yard waste drop-off
+
+      </h3>
+    </div>
+
+  </div>
+</div>
+
+      
+<div class="mobile-1-col tablet-1-col xxl-desktop-2-col clearfix news-item news-item-short-listing news-item-public_notice">
+  <a href="https://www.boston.gov/public-notices/11565516" class="item-link"></a>
+  <div class="news-item-wrapper">
+
+    <div class="thumb-wrapper float-left">
+
+              <div class="news-item-default-image">
+          <span>Image for Committee on Ways and Means Working Session on Dockets #0588-0596, FY21 Budget: BPS Alignment, Wraparound Supports, and Specialized Academic Supports
+</span>
+        </div>
+      
+      <div class="date-flag">
+        Apr 27
+      </div>
+
+    </div>
+
+    <div class="text-wrapper">
+      <h3 class="title">
+        Committee on Ways and Means Working Session on Dockets #0588-0596, FY21 Budget: BPS Alignment, Wraparound Supports, and Specialized Academic Supports
+
+      </h3>
+    </div>
+
+  </div>
+</div>
+
+      
+<div class="mobile-1-col tablet-1-col xxl-desktop-2-col clearfix news-item news-item-short-listing news-item-public_notice">
+  <a href="https://www.boston.gov/public-notices/11566011" class="item-link"></a>
+  <div class="news-item-wrapper">
+
+    <div class="thumb-wrapper float-left">
+
+              <div class="news-item-default-image">
+          <span>Image for Committee on Veterans and Military Affairs Hearing on Docket #0579
+</span>
+        </div>
+      
+      <div class="date-flag">
+        Apr 27
+      </div>
+
+    </div>
+
+    <div class="text-wrapper">
+      <h3 class="title">
+        Committee on Veterans and Military Affairs Hearing on Docket #0579
+
+      </h3>
+    </div>
+
+  </div>
+</div>
+
+  </div>
+
+    
+
+  
+  
+
+  
+  
+</div>
+</div>
+
+  
+</div>
+
+
+    </div>
+
+          
+              <a href="https://www.boston.gov/events" class="btn">Find more events</a>
+      
+
+
+    
+  </div>
+</div>
+
+                            <a class="subnav-anchor" name="mayor-martin-j-walsh" data-text="Mayor Martin J. Walsh"></a>
+                
+<div class="entity entity-paragraphs-item paragraphs-item-text component-section entity entity-paragraphs-item component-section" bos_context_type="Text" about="" typeof="">
+  <div class="content">
+      	  <div class="sh">
+        
+    <h2 class="sh-title">Boston Mayor Martin J. Walsh</h2>
+
+                  <div class="field field-label-hidden field-name-field-contact field-type-entity-reference sh-contact">
+      Contact: <a href="https://www.boston.gov/contact/mayors-office" hreflang="en">Mayor's Office</a>
+  </div>
+
+              </div>
+              <div class="paragraphs-items paragraphs-items-field-text-blocks paragraphs-items-field-text-blocks-full paragraphs-items-full">
+                     
+<div class="entity entity-paragraphs-item paragraphs-item-text-two-column component-section col_half entity entity-paragraphs-item component-section" bos_context_type="Text Two Column">
+
+  <div class="content">
+        <div class="field field-label-hidden field-name-field-left-column field-type-text-long field-items">
+            <p></p><div data-embed-button="media_entity_embed" data-entity-embed-display="bos_media_image" data-entity-type="media" data-entity-uuid="5a52199d-6844-4b3c-ba37-49c82f2da4af" alt="Image for mayor martin j walsh" height="731" width="1200" class="media-element file-default embedded-entity" data-langcode="und">    
+      <img src="./Boston.gov_files/mayor-walsh2.jpg" width="1200" height="731" alt="Image for mayor martin j walsh" title="mayor martin j walsh" typeof="foaf:Image"></div>
+<p></p>
+
+          </div>
+    <div class="field field-label-hidden field-name-field-right-column field-type-text-long field-items">
+            <p class="supporting-text">Meet the Mayor</p>
+<p>Mayor Martin J. Walsh, an accomplished advocate for working people and a proud product of the City of Boston, was sworn in as the City’s 54th Mayor on January 6, 2014.&nbsp;</p>
+<p><a class="button" href="https://www.boston.gov/node/501">Learn more about Mayor Walsh</a></p>
+
+          </div>
+
+  </div>
+
+</div>
+
+      
+      </div>
+      </div>
+</div>
+
+                            <a class="subnav-anchor" name="city-council" data-text="City Council"></a>
+                
+<div class="b--g b--fw b">
+
+  <div class="b-c">
+
+    <div class="sh m--b000">
+
+      
+
+              
+    <h2 class="sh-title">Boston City Council</h2>
+
+      
+              	<span class="field field-name-field-short-title field-type-text field-type-string component-short-title">
+		City Council
+	</span>
+
+      
+              <div class="field field-name-field-contact field-type-entity-reference sh-contact">
+      Contact: <a href="https://www.boston.gov/contact/city-council" hreflang="en">City Council</a>
+  </div>
+
+      
+    </div>
+
+    <div class="g">
+                  <article class="contextual-region node-38046 clearfix node modstate-published cdp m-t500 g--1 g--3--sl" bos_context_type="Person Profile">
+  <a href="https://www.boston.gov/departments/city-council/kim-janey" class="cdp-l d-b p-a300">
+
+                    <div class="cdp-i field-item">
+        <article>
+                      <picture>
+                <!--[if IE 9]><video style="display: none;"><![endif]-->
+              <source srcset="/sites/default/files/styles/person_photo_a_mobile_1x/public/img/library/photos/2020/01/janey-headshot.jpg?itok=tJQKBXAF 1x" media="(max-width: 839px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_b_tablet_1x/public/img/library/photos/2020/01/janey-headshot.jpg?itok=lgs7Bf93 1x" media="(min-width: 840px)  and (max-width: 979px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_c_desktop_1x/public/img/library/photos/2020/01/janey-headshot.jpg?itok=UDXwxMAN 1x" media="(min-width: 980px) and (max-width: 1279px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_profile_card_173x173_/public/img/library/photos/2020/01/janey-headshot.jpg?itok=L6o3yPIv 1x" media="(min-width: 1280px)" type="image/jpeg">
+            <!--[if IE 9]></video><![endif]-->
+              
+      <img class="cdp-i" src="./Boston.gov_files/janey-headshot.jpg" alt="Kim Janey" typeof="foaf:Image">
+
+  
+  </picture>
+
+
+      
+  </article>
+
+            </div>
+      
+
+    <div>
+
+      <div class="cdp-t t--sans t--upper">
+        Kim Janey
+      </div>
+
+              <div class="cdp-st t--subinfo t--g300">
+                      City Council President, City Councilor, District 7
+      
+        </div>
+      
+    </div>
+
+  </a>
+
+  
+    
+        <a href="tel:617-635-3510" class="d-b bg--cb cdp-a ta-c p-a300 t--upper t--sans t--w t--ob--h t--s100">617-635-3510</a>
+
+
+    
+  
+</article>
+
+              <article class="contextual-region node-421 clearfix node modstate-published cdp m-t500 g--1 g--3--sl" bos_context_type="Person Profile">
+  <a href="https://www.boston.gov/departments/city-council/annissa-essaibi-george" class="cdp-l d-b p-a300">
+
+                    <div class="cdp-i field-item">
+        <article>
+                      <picture>
+                <!--[if IE 9]><video style="display: none;"><![endif]-->
+              <source srcset="/sites/default/files/styles/person_photo_a_mobile_1x/public/img/library/photos/2020/01/anissa-headshot.jpg?itok=gTkdjQ48 1x" media="(max-width: 839px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_b_tablet_1x/public/img/library/photos/2020/01/anissa-headshot.jpg?itok=dVRqC6sQ 1x" media="(min-width: 840px)  and (max-width: 979px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_c_desktop_1x/public/img/library/photos/2020/01/anissa-headshot.jpg?itok=w3ida0TH 1x" media="(min-width: 980px) and (max-width: 1279px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_profile_card_173x173_/public/img/library/photos/2020/01/anissa-headshot.jpg?itok=8JcuNs62 1x" media="(min-width: 1280px)" type="image/jpeg">
+            <!--[if IE 9]></video><![endif]-->
+              
+      <img class="cdp-i" src="./Boston.gov_files/anissa-headshot.jpg" alt="Annissa Essaibi George" typeof="foaf:Image">
+
+  
+  </picture>
+
+
+      
+  </article>
+
+            </div>
+      
+
+    <div>
+
+      <div class="cdp-t t--sans t--upper">
+        Annissa Essaibi George
+      </div>
+
+              <div class="cdp-st t--subinfo t--g300">
+                      City Councilor, At-Large
+      
+        </div>
+      
+    </div>
+
+  </a>
+
+  
+    
+      
+  <a href="mailto:A.E.George@boston.gov" class="d-b bg--cb cdp-a ta-c p-a300 t--upper t--sans t--w t--ob--h t--s100">
+    Send an email
+    <span class="a11y--hidden"> to A.E.George@boston.gov</span>
+  </a>
+
+
+    
+  
+</article>
+
+              <article class="contextual-region node-411 clearfix node modstate-published cdp m-t500 g--1 g--3--sl" bos_context_type="Person Profile">
+  <a href="https://www.boston.gov/departments/city-council/michael-flaherty" class="cdp-l d-b p-a300">
+
+                    <div class="cdp-i field-item">
+        <article>
+                      <picture>
+                <!--[if IE 9]><video style="display: none;"><![endif]-->
+              <source srcset="/sites/default/files/styles/person_photo_a_mobile_1x/public/img/2016/f/flaherty360.jpg?itok=H4LTxZEj 1x" media="(max-width: 839px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_b_tablet_1x/public/img/2016/f/flaherty360.jpg?itok=7Lhh8xHC 1x" media="(min-width: 840px)  and (max-width: 979px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_c_desktop_1x/public/img/2016/f/flaherty360.jpg?itok=i9CAbrKz 1x" media="(min-width: 980px) and (max-width: 1279px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_profile_card_173x173_/public/img/2016/f/flaherty360.jpg?itok=nGLIYZ1a 1x" media="(min-width: 1280px)" type="image/jpeg">
+            <!--[if IE 9]></video><![endif]-->
+              
+      <img class="cdp-i" src="./Boston.gov_files/flaherty360.jpg" alt="Image for flaherty360" typeof="foaf:Image">
+
+  
+  </picture>
+
+
+      
+  </article>
+
+            </div>
+      
+
+    <div>
+
+      <div class="cdp-t t--sans t--upper">
+        Michael Flaherty
+      </div>
+
+              <div class="cdp-st t--subinfo t--g300">
+                      City Councilor, At-Large
+      
+        </div>
+      
+    </div>
+
+  </a>
+
+  
+    
+      
+  <a href="mailto:Michael.F.Flaherty@boston.gov" class="d-b bg--cb cdp-a ta-c p-a300 t--upper t--sans t--w t--ob--h t--s100">
+    Send an email
+    <span class="a11y--hidden"> to Michael.F.Flaherty@boston.gov</span>
+  </a>
+
+
+    
+  
+</article>
+
+              <article class="contextual-region node-11555266 clearfix node modstate-published cdp m-t500 g--1 g--3--sl" bos_context_type="Person Profile">
+  <a href="https://www.boston.gov/departments/city-council/julia-mejia" class="cdp-l d-b p-a300">
+
+                    <div class="cdp-i field-item">
+        <article>
+                      <picture>
+                <!--[if IE 9]><video style="display: none;"><![endif]-->
+              <source srcset="/sites/default/files/styles/person_photo_a_mobile_1x/public/img/library/photos/2020/01/mejia-headshot.jpg?itok=y9yV-vpa 1x" media="(max-width: 839px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_b_tablet_1x/public/img/library/photos/2020/01/mejia-headshot.jpg?itok=kCPTHBEi 1x" media="(min-width: 840px)  and (max-width: 979px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_c_desktop_1x/public/img/library/photos/2020/01/mejia-headshot.jpg?itok=QgW5WTUX 1x" media="(min-width: 980px) and (max-width: 1279px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_profile_card_173x173_/public/img/library/photos/2020/01/mejia-headshot.jpg?itok=EQ99_HNW 1x" media="(min-width: 1280px)" type="image/jpeg">
+            <!--[if IE 9]></video><![endif]-->
+              
+      <img class="cdp-i" src="./Boston.gov_files/mejia-headshot.jpg" alt="Julia Mejia" typeof="foaf:Image">
+
+  
+  </picture>
+
+
+      
+  </article>
+
+            </div>
+      
+
+    <div>
+
+      <div class="cdp-t t--sans t--upper">
+        Julia Mejia
+      </div>
+
+              <div class="cdp-st t--subinfo t--g300">
+                      City Councilor, At-Large
+      
+        </div>
+      
+    </div>
+
+  </a>
+
+  
+    
+        <a href="tel:617-635-4217" class="d-b bg--cb cdp-a ta-c p-a300 t--upper t--sans t--w t--ob--h t--s100">617-635-4217</a>
+
+
+    
+  
+</article>
+
+              <article class="contextual-region node-396 clearfix node modstate-published cdp m-t500 g--1 g--3--sl" bos_context_type="Person Profile">
+  <a href="https://www.boston.gov/departments/city-council/michelle-wu" class="cdp-l d-b p-a300">
+
+                    <div class="cdp-i field-item">
+        <article>
+                      <picture>
+                <!--[if IE 9]><video style="display: none;"><![endif]-->
+              <source srcset="/sites/default/files/styles/person_photo_a_mobile_1x/public/img/library/photos/2020/01/wu-headshot.jpg?itok=ZghjO8oI 1x" media="(max-width: 839px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_b_tablet_1x/public/img/library/photos/2020/01/wu-headshot.jpg?itok=j6hEfcgm 1x" media="(min-width: 840px)  and (max-width: 979px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_c_desktop_1x/public/img/library/photos/2020/01/wu-headshot.jpg?itok=z0onSxKj 1x" media="(min-width: 980px) and (max-width: 1279px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_profile_card_173x173_/public/img/library/photos/2020/01/wu-headshot.jpg?itok=PtTgk9NL 1x" media="(min-width: 1280px)" type="image/jpeg">
+            <!--[if IE 9]></video><![endif]-->
+              
+      <img class="cdp-i" src="./Boston.gov_files/wu-headshot.jpg" alt="Michelle Wu" typeof="foaf:Image">
+
+  
+  </picture>
+
+
+      
+  </article>
+
+            </div>
+      
+
+    <div>
+
+      <div class="cdp-t t--sans t--upper">
+        Michelle Wu
+      </div>
+
+              <div class="cdp-st t--subinfo t--g300">
+                      City Councilor, At-Large
+      
+        </div>
+      
+    </div>
+
+  </a>
+
+  
+    
+      
+  <a href="mailto:Michelle.Wu@boston.gov" class="d-b bg--cb cdp-a ta-c p-a300 t--upper t--sans t--w t--ob--h t--s100">
+    Send an email
+    <span class="a11y--hidden"> to Michelle.Wu@boston.gov</span>
+  </a>
+
+
+    
+  
+</article>
+
+              <article class="contextual-region node-38036 clearfix node modstate-published cdp m-t500 g--1 g--3--sl" bos_context_type="Person Profile">
+  <a href="https://www.boston.gov/departments/city-council/lydia-edwards" class="cdp-l d-b p-a300">
+
+                    <div class="cdp-i field-item">
+        <article>
+                      <picture>
+                <!--[if IE 9]><video style="display: none;"><![endif]-->
+              <source srcset="/sites/default/files/styles/person_photo_a_mobile_1x/public/img/library/photos/2020/01/lydia-headshot.jpg?itok=Pdxub1cr 1x" media="(max-width: 839px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_b_tablet_1x/public/img/library/photos/2020/01/lydia-headshot.jpg?itok=was_wjj5 1x" media="(min-width: 840px)  and (max-width: 979px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_c_desktop_1x/public/img/library/photos/2020/01/lydia-headshot.jpg?itok=cSjRVbZ1 1x" media="(min-width: 980px) and (max-width: 1279px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_profile_card_173x173_/public/img/library/photos/2020/01/lydia-headshot.jpg?itok=CicwusgP 1x" media="(min-width: 1280px)" type="image/jpeg">
+            <!--[if IE 9]></video><![endif]-->
+              
+      <img class="cdp-i" src="./Boston.gov_files/lydia-headshot.jpg" alt="Lydia Edwards" typeof="foaf:Image">
+
+  
+  </picture>
+
+
+      
+  </article>
+
+            </div>
+      
+
+    <div>
+
+      <div class="cdp-t t--sans t--upper">
+        Lydia Edwards
+      </div>
+
+              <div class="cdp-st t--subinfo t--g300">
+                      City Councilor, District 1
+      
+        </div>
+      
+    </div>
+
+  </a>
+
+  
+    
+      
+  <a href="mailto:lydia.edwards@boston.gov" class="d-b bg--cb cdp-a ta-c p-a300 t--upper t--sans t--w t--ob--h t--s100">
+    Send an email
+    <span class="a11y--hidden"> to lydia.edwards@boston.gov</span>
+  </a>
+
+
+    
+  
+</article>
+
+              <article class="contextual-region node-38041 clearfix node modstate-published cdp m-t500 g--1 g--3--sl" bos_context_type="Person Profile">
+  <a href="https://www.boston.gov/departments/city-council/ed-flynn" class="cdp-l d-b p-a300">
+
+                    <div class="cdp-i field-item">
+        <article>
+                      <picture>
+                <!--[if IE 9]><video style="display: none;"><![endif]-->
+              <source srcset="/sites/default/files/styles/person_photo_a_mobile_1x/public/img/person_profile/photos/2018/01/flynn-headshot.jpg?itok=H5DBRdu8 1x" media="(max-width: 839px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_b_tablet_1x/public/img/person_profile/photos/2018/01/flynn-headshot.jpg?itok=cQ7tWA7q 1x" media="(min-width: 840px)  and (max-width: 979px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_c_desktop_1x/public/img/person_profile/photos/2018/01/flynn-headshot.jpg?itok=1pYXvkjd 1x" media="(min-width: 980px) and (max-width: 1279px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_profile_card_173x173_/public/img/person_profile/photos/2018/01/flynn-headshot.jpg?itok=vR6ZRvY4 1x" media="(min-width: 1280px)" type="image/jpeg">
+            <!--[if IE 9]></video><![endif]-->
+              
+      <img class="cdp-i" src="./Boston.gov_files/flynn-headshot.jpg" alt="Image for edward flynn" typeof="foaf:Image">
+
+  
+  </picture>
+
+
+      
+  </article>
+
+            </div>
+      
+
+    <div>
+
+      <div class="cdp-t t--sans t--upper">
+        Ed Flynn
+      </div>
+
+              <div class="cdp-st t--subinfo t--g300">
+                      City Councilor, District 2
+      
+        </div>
+      
+    </div>
+
+  </a>
+
+  
+    
+      
+  <a href="mailto:ed.flynn@boston.gov" class="d-b bg--cb cdp-a ta-c p-a300 t--upper t--sans t--w t--ob--h t--s100">
+    Send an email
+    <span class="a11y--hidden"> to ed.flynn@boston.gov</span>
+  </a>
+
+
+    
+  
+</article>
+
+              <article class="contextual-region node-456 clearfix node modstate-published cdp m-t500 g--1 g--3--sl" bos_context_type="Person Profile">
+  <a href="https://www.boston.gov/departments/city-council/frank-baker" class="cdp-l d-b p-a300">
+
+                    <div class="cdp-i field-item">
+        <article>
+                      <picture>
+                <!--[if IE 9]><video style="display: none;"><![endif]-->
+              <source srcset="/sites/default/files/styles/person_photo_a_mobile_1x/public/img/library/photos/2020/01/baker-headshot.jpg?itok=X6A_qNWg 1x" media="(max-width: 839px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_b_tablet_1x/public/img/library/photos/2020/01/baker-headshot.jpg?itok=-sO9E_Ct 1x" media="(min-width: 840px)  and (max-width: 979px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_c_desktop_1x/public/img/library/photos/2020/01/baker-headshot.jpg?itok=OW6nQizR 1x" media="(min-width: 980px) and (max-width: 1279px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_profile_card_173x173_/public/img/library/photos/2020/01/baker-headshot.jpg?itok=aJrzW_Qa 1x" media="(min-width: 1280px)" type="image/jpeg">
+            <!--[if IE 9]></video><![endif]-->
+              
+      <img class="cdp-i" src="./Boston.gov_files/baker-headshot.jpg" alt="Frank Baker" typeof="foaf:Image">
+
+  
+  </picture>
+
+
+      
+  </article>
+
+            </div>
+      
+
+    <div>
+
+      <div class="cdp-t t--sans t--upper">
+        Frank Baker
+      </div>
+
+              <div class="cdp-st t--subinfo t--g300">
+                      City Councilor, District 3
+      
+        </div>
+      
+    </div>
+
+  </a>
+
+  
+    
+      
+  <a href="mailto:Frank.Baker@boston.gov" class="d-b bg--cb cdp-a ta-c p-a300 t--upper t--sans t--w t--ob--h t--s100">
+    Send an email
+    <span class="a11y--hidden"> to Frank.Baker@boston.gov</span>
+  </a>
+
+
+    
+  
+</article>
+
+              <article class="contextual-region node-446 clearfix node modstate-published cdp m-t500 g--1 g--3--sl" bos_context_type="Person Profile">
+  <a href="https://www.boston.gov/departments/city-council/andrea-campbell" class="cdp-l d-b p-a300">
+
+                    <div class="cdp-i field-item">
+        <article>
+                      <picture>
+                <!--[if IE 9]><video style="display: none;"><![endif]-->
+              <source srcset="/sites/default/files/styles/person_photo_a_mobile_1x/public/img/person_profile/photos/2018/01/campell-headshot.jpg?itok=Q1Wypsn8 1x" media="(max-width: 839px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_b_tablet_1x/public/img/person_profile/photos/2018/01/campell-headshot.jpg?itok=pzdyUiDk 1x" media="(min-width: 840px)  and (max-width: 979px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_c_desktop_1x/public/img/person_profile/photos/2018/01/campell-headshot.jpg?itok=qhS78R4v 1x" media="(min-width: 980px) and (max-width: 1279px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_profile_card_173x173_/public/img/person_profile/photos/2018/01/campell-headshot.jpg?itok=RNGCHBZ5 1x" media="(min-width: 1280px)" type="image/jpeg">
+            <!--[if IE 9]></video><![endif]-->
+              
+      <img class="cdp-i" src="./Boston.gov_files/campell-headshot.jpg" alt="Image for andrea campbell" typeof="foaf:Image">
+
+  
+  </picture>
+
+
+      
+  </article>
+
+            </div>
+      
+
+    <div>
+
+      <div class="cdp-t t--sans t--upper">
+        Andrea Campbell
+      </div>
+
+              <div class="cdp-st t--subinfo t--g300">
+                      City Councilor, District 4
+      
+        </div>
+      
+    </div>
+
+  </a>
+
+  
+    
+      
+  <a href="mailto:Andrea.Campbell@boston.gov" class="d-b bg--cb cdp-a ta-c p-a300 t--upper t--sans t--w t--ob--h t--s100">
+    Send an email
+    <span class="a11y--hidden"> to Andrea.Campbell@boston.gov</span>
+  </a>
+
+
+    
+  
+</article>
+
+              <article class="contextual-region node-11555246 clearfix node modstate-published cdp m-t500 g--1 g--3--sl" bos_context_type="Person Profile">
+  <a href="https://www.boston.gov/departments/city-council/ricardo-arroyo" class="cdp-l d-b p-a300">
+
+                    <div class="cdp-i field-item">
+        <article>
+                      <picture>
+                <!--[if IE 9]><video style="display: none;"><![endif]-->
+              <source srcset="/sites/default/files/styles/person_photo_a_mobile_1x/public/img/library/photos/2020/02/Arroyo_Ricardo%20%281%29%20copy.jpg?itok=mm9eUh26 1x" media="(max-width: 839px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_b_tablet_1x/public/img/library/photos/2020/02/Arroyo_Ricardo%20%281%29%20copy.jpg?itok=cF1hf7Ie 1x" media="(min-width: 840px)  and (max-width: 979px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_c_desktop_1x/public/img/library/photos/2020/02/Arroyo_Ricardo%20%281%29%20copy.jpg?itok=Ec3uDpBd 1x" media="(min-width: 980px) and (max-width: 1279px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_profile_card_173x173_/public/img/library/photos/2020/02/Arroyo_Ricardo%20%281%29%20copy.jpg?itok=3Lem5CjG 1x" media="(min-width: 1280px)" type="image/jpeg">
+            <!--[if IE 9]></video><![endif]-->
+              
+      <img class="cdp-i" src="./Boston.gov_files/Arroyo_Ricardo (1) copy.jpg" alt="Ricardo Arroyo photo" typeof="foaf:Image">
+
+  
+  </picture>
+
+
+      
+  </article>
+
+            </div>
+      
+
+    <div>
+
+      <div class="cdp-t t--sans t--upper">
+        Ricardo Arroyo
+      </div>
+
+              <div class="cdp-st t--subinfo t--g300">
+                      City Councilor, District 5
+      
+        </div>
+      
+    </div>
+
+  </a>
+
+  
+    
+      
+  <a href="mailto:ricardo.arroyo@boston.gov" class="d-b bg--cb cdp-a ta-c p-a300 t--upper t--sans t--w t--ob--h t--s100">
+    Send an email
+    <span class="a11y--hidden"> to ricardo.arroyo@boston.gov</span>
+  </a>
+
+
+    
+  
+</article>
+
+              <article class="contextual-region node-426 clearfix node modstate-published cdp m-t500 g--1 g--3--sl" bos_context_type="Person Profile">
+  <a href="https://www.boston.gov/departments/city-council/matt-omalley" class="cdp-l d-b p-a300">
+
+                    <div class="cdp-i field-item">
+        <article>
+                      <picture>
+                <!--[if IE 9]><video style="display: none;"><![endif]-->
+              <source srcset="/sites/default/files/styles/person_photo_a_mobile_1x/public/img/library/photos/2020/01/omalley-headshot.jpg?itok=29UCkJRu 1x" media="(max-width: 839px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_b_tablet_1x/public/img/library/photos/2020/01/omalley-headshot.jpg?itok=1ATxfQqn 1x" media="(min-width: 840px)  and (max-width: 979px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_c_desktop_1x/public/img/library/photos/2020/01/omalley-headshot.jpg?itok=WOKqgGgd 1x" media="(min-width: 980px) and (max-width: 1279px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_profile_card_173x173_/public/img/library/photos/2020/01/omalley-headshot.jpg?itok=y1Q0bv7F 1x" media="(min-width: 1280px)" type="image/jpeg">
+            <!--[if IE 9]></video><![endif]-->
+              
+      <img class="cdp-i" src="./Boston.gov_files/omalley-headshot.jpg" alt="Matt O&#39;Malley" typeof="foaf:Image">
+
+  
+  </picture>
+
+
+      
+  </article>
+
+            </div>
+      
+
+    <div>
+
+      <div class="cdp-t t--sans t--upper">
+        Matt O'Malley
+      </div>
+
+              <div class="cdp-st t--subinfo t--g300">
+                      City Councilor, District 6
+      
+        </div>
+      
+    </div>
+
+  </a>
+
+  
+    
+      
+  <a href="mailto:matthew.omalley@boston.gov" class="d-b bg--cb cdp-a ta-c p-a300 t--upper t--sans t--w t--ob--h t--s100">
+    Send an email
+    <span class="a11y--hidden"> to matthew.omalley@boston.gov</span>
+  </a>
+
+
+    
+  
+</article>
+
+              <article class="contextual-region node-11555256 clearfix node modstate-published cdp m-t500 g--1 g--3--sl" bos_context_type="Person Profile">
+  <a href="https://www.boston.gov/departments/city-council/kenzie-bok" class="cdp-l d-b p-a300">
+
+                    <div class="cdp-i field-item">
+        <article>
+                      <picture>
+                <!--[if IE 9]><video style="display: none;"><![endif]-->
+              <source srcset="/sites/default/files/styles/person_photo_a_mobile_1x/public/img/library/photos/2020/01/bok-headshot_0.jpg?itok=BBoQGbD8 1x" media="(max-width: 839px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_b_tablet_1x/public/img/library/photos/2020/01/bok-headshot_0.jpg?itok=ORFzaHij 1x" media="(min-width: 840px)  and (max-width: 979px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_c_desktop_1x/public/img/library/photos/2020/01/bok-headshot_0.jpg?itok=MxGUgDnS 1x" media="(min-width: 980px) and (max-width: 1279px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_profile_card_173x173_/public/img/library/photos/2020/01/bok-headshot_0.jpg?itok=pcVw_u0g 1x" media="(min-width: 1280px)" type="image/jpeg">
+            <!--[if IE 9]></video><![endif]-->
+              
+      <img class="cdp-i" src="./Boston.gov_files/bok-headshot_0.jpg" alt="Priscilla Bok" typeof="foaf:Image">
+
+  
+  </picture>
+
+
+      
+  </article>
+
+            </div>
+      
+
+    <div>
+
+      <div class="cdp-t t--sans t--upper">
+        Kenzie Bok
+      </div>
+
+              <div class="cdp-st t--subinfo t--g300">
+                      City Councilor, District 8
+      
+        </div>
+      
+    </div>
+
+  </a>
+
+  
+    
+      
+  <a href="mailto:kenzie.bok@boston.gov" class="d-b bg--cb cdp-a ta-c p-a300 t--upper t--sans t--w t--ob--h t--s100">
+    Send an email
+    <span class="a11y--hidden"> to kenzie.bok@boston.gov</span>
+  </a>
+
+
+    
+  
+</article>
+
+              <article class="contextual-region node-11555261 clearfix node modstate-published cdp m-t500 g--1 g--3--sl" bos_context_type="Person Profile">
+  <a href="https://www.boston.gov/departments/city-council/liz-breadon" class="cdp-l d-b p-a300">
+
+                    <div class="cdp-i field-item">
+        <article>
+                      <picture>
+                <!--[if IE 9]><video style="display: none;"><![endif]-->
+              <source srcset="/sites/default/files/styles/person_photo_a_mobile_1x/public/img/library/photos/2020/01/breadon-headshot.jpg?itok=zt2H8aVL 1x" media="(max-width: 839px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_b_tablet_1x/public/img/library/photos/2020/01/breadon-headshot.jpg?itok=c2Sq7cb7 1x" media="(min-width: 840px)  and (max-width: 979px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_photo_c_desktop_1x/public/img/library/photos/2020/01/breadon-headshot.jpg?itok=xc22TBXD 1x" media="(min-width: 980px) and (max-width: 1279px)" type="image/jpeg">
+              <source srcset="/sites/default/files/styles/person_profile_card_173x173_/public/img/library/photos/2020/01/breadon-headshot.jpg?itok=2TMnbx42 1x" media="(min-width: 1280px)" type="image/jpeg">
+            <!--[if IE 9]></video><![endif]-->
+              
+      <img class="cdp-i" src="./Boston.gov_files/breadon-headshot.jpg" alt="Liz Breadon" typeof="foaf:Image">
+
+  
+  </picture>
+
+
+      
+  </article>
+
+            </div>
+      
+
+    <div>
+
+      <div class="cdp-t t--sans t--upper">
+        Liz Breadon
+      </div>
+
+              <div class="cdp-st t--subinfo t--g300">
+                      City Councilor, District 9
+      
+        </div>
+      
+    </div>
+
+  </a>
+
+  
+    
+        <a href="tel:617-635-3113" class="d-b bg--cb cdp-a ta-c p-a300 t--upper t--sans t--w t--ob--h t--s100">617-635-3113</a>
+
+
+    
+  
+</article>
+
+      
+    </div>
+
+  </div>
+
+</div>
+
+                    </div>
+    
+
+</article>
+
+  
+
+        
+
+      </section>
+    </div>
+  </div>
+  
+<footer class="ft">
+    <div class="ft-c">
+        <ul class="ft-ll ft-ll--r">
+            <li class="ft-ll-i"><a href="http://www.cityofboston.gov/311/" class="ft-ll-a lnk--yellow"><span class="ft-ll-311">BOS:311</span><span class="tablet--hidden"> - </span>Report an issue</a></li>
+        </ul>
+        <nav role="navigation" aria-labelledby="block-footermenu-menu" id="block-footermenu" data-block-plugin-id="menu_block:menu-footer-menu">
+            
+  <h2 class="visually-hidden" id="block-footermenu-menu">Footer menu</h2>
+  
+
+        
+                            <ul class="ft-ll">
+                            <li class="ft-ll-i ft-ll-a">
+                <a href="https://www.boston.gov/departments/innovation-and-technology/terms-use-and-privacy-policy" target="_blank" title="" data-drupal-link-system-path="node/31526">Privacy Policy</a>
+                            </li>
+                    <li class="ft-ll-i ft-ll-a">
+                <a href="https://www.boston.gov/departments/mayors-office/contact-boston-city-hall" title="" data-drupal-link-system-path="node/1806">Contact us</a>
+                            </li>
+                    <li class="ft-ll-i ft-ll-a">
+                <a href="https://www.boston.gov/departments/711/city-boston-alerts-and-notifications" title="" data-drupal-link-system-path="node/31131">Alerts and notifications</a>
+                            </li>
+                    <li class="ft-ll-i ft-ll-a">
+                <a href="https://www.boston.gov/departments/public-records" title="" data-drupal-link-system-path="node/16136">Public records requests</a>
+                            </li>
+                </ul>
+    
+
+
+  </nav>
+
+    </div>
+</footer>
+
+</div>
+
+
+
+
+  </div>
+
+    
+
+    <script id="contactFormTemplate" type="text/x-template">
+    <div class="md">
+        <div class="md-c">
+            <button class="md-cb">Close</button>
+            <div class="mb-b p-a300 p-a600--xl">
+                <div class="sh m-b500">
+                    <div class="sh-title">Contact Us</div>
+                </div>
+                <div>
+                    <div id="contactMessage" class="t--info m-b500">Have a question, or just need help? You can send an email through the form below.</div>
+                    <form id="contactForm" action="https://contactform.boston.gov/emails" method="POST">
+                        <input id="contactFormToAddress" name="email[to_address]" type="hidden" value="">
+                        <input id="contactFormURL" name="email[url]" type="hidden" value="">
+                        <input id="contactFormBrowser" name="email[browser]" type="hidden" value="">
+                        <div class="fs">
+                            <div class="fs-c">
+                                <div class="txt m-b300">
+                                    <label for="contact-name" class="txt-l txt-l--mt000">Full Name</label>
+                                    <input id="contact-name" name="email[name]" type="text" class="txt-f bos-contact-name" size="10" value="">
+                                </div>
+                                <div class="txt m-b300">
+                                    <label for="contact-address" class="txt-l txt-l--mt000">Email Address</label>
+                                    <input id="contact-address" name="email[from_address]" type="text" placeholder="email@address.com" class="txt-f bos-contact-email" value="">
+                                </div>
+                                <div class="txt m-b300">
+                                    <label for="contact-subject" class="txt-l txt-l--mt000">Subject</label>
+                                    <input id="contact-subject" name="email[subject]" type="text" class="txt-f bos-contact-subject" size="10" value="">
+                                </div>
+                                <div class="txt m-b300">
+                                    <label for="contact-message" class="txt-l txt-l--mt000">Message</label>
+                                    <textarea id="contact-message" name="email[message]" type="text" class="txt-f bos-contact-message" rows="10"></textarea>
+                                </div>
+                            </div>
+                            <div class="bc bc--r p-t500">
+                                <button type="submit" class="btn btn--700">Send Message</button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</script>
+
+    <script type="application/json" data-drupal-selector="drupal-settings-json">{"path":{"baseUrl":"\/","scriptPath":null,"pathPrefix":"","currentPath":"node\/21","currentPathIsAdmin":false,"isFront":true,"currentLanguage":"en"},"pluralDelimiter":"\u0003","suppressDeprecationErrors":true,"ajaxPageState":{"libraries":"bos_bibblio\/bos_bibblio_css,bos_components\/field.style,bos_lightbox\/lity,bos_theme\/context_link,bos_theme\/fleet-components.patterns,bos_theme\/global-styling.always,bos_theme\/global-styling.patterns,bos_theme\/page.assets,bos_theme\/page.inpage_menu,core\/html5shiv,core\/picturefill,node_emergency_alert\/emergency_alert.call,paragraphs\/drupal.paragraphs.unpublished,poll\/drupal.poll-links,system\/base,views\/views.module","theme":"bos_theme","theme_token":null},"ajaxTrustedUrl":[],"ajax":[],"user":{"uid":0,"permissionsHash":"712ef0b5061a59d37cab2f9ca274bac63f7496e8fe8c4c3f94ae3bc247e529fb"}}</script>
+<script src="./Boston.gov_files/js_avfsPBJgIAekwWKDb8PUvNsZOCD3q33JQpzZmI-K7BI.js"></script>
+<script src="./Boston.gov_files/bos_theme.context_menu_link.js" id="bos_theme_context_menu_link"></script>
+<script src="./Boston.gov_files/bos_theme.contextual_toolbar_tab.js" id="bos_core_contextual_toolbar_tab"></script>
+<script src="./Boston.gov_files/fleetcomponents.js"></script>
+<script src="./Boston.gov_files/lity.min.js"></script>
+<script src="./Boston.gov_files/inpage_menu.boston.js" id="inpage_menu_script"></script>
+<script src="./Boston.gov_files/emergency_alert.boston.js" id="emergency_alert_script"></script>
+<script src="./Boston.gov_files/messages.boston.js" id="messages_script"></script>
+<script src="./Boston.gov_files/cob_ckeditor.boston.js" id="cob_ckeditor_script"></script>
+
+<!--[if IE 9]>
+<script src="/sites/default/files/js/js_VazMdB7n5VPCNUi7EMTSESLbwkO6VhD4Na_uxRUyHh4.js"></script>
+<![endif]-->
+<script src="./Boston.gov_files/js_i3CdBGUcbCeiVJC_EqAW0xz1stha808_jeLEUBYj6T0.js"></script>
+<script src="./Boston.gov_files/all.js"></script>
+
+  <script type="text/javascript">window.NREUM||(NREUM={});NREUM.info={"beacon":"bam.nr-data.net","licenseKey":"06206dff86","applicationID":"449797348","transactionName":"M1ZQYkVZXRUCARBaDgocc1VDUVwITCYWRhEFX251WEpWOi4HCkY9IFZUV0JURysGDBF\/CApYZkRSXX4HDQsURg0FR11ERBUNAQYMAUEAEFZ7WFNdSycNBjdcExA=","queueTime":0,"applicationTime":14526,"atts":"HxFTFA1DThs=","errorBeacon":"bam.nr-data.net","agent":""}</script>
+
+</body></html>

--- a/mycity/mycity/test/test_data/CoronavirusDiseaseinBoston.gov.html
+++ b/mycity/mycity/test/test_data/CoronavirusDiseaseinBoston.gov.html
@@ -1,0 +1,2323 @@
+<!DOCTYPE html>
+<!-- saved from url=(0063)https://www.boston.gov/news/coronavirus-disease-covid-19-boston -->
+<html lang="en" dir="ltr" prefix="content: http://purl.org/rss/1.0/modules/content/  dc: http://purl.org/dc/terms/  foaf: http://xmlns.com/foaf/0.1/  og: http://ogp.me/ns#  rdfs: http://www.w3.org/2000/01/rdf-schema#  schema: http://schema.org/  sioc: http://rdfs.org/sioc/ns#  sioct: http://rdfs.org/sioc/types#  skos: http://www.w3.org/2004/02/skos/core#  xsd: http://www.w3.org/2001/XMLSchema# " style="" class=" no-touchevents details js flexbox"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <style data-styles="">cob-chart,cob-contact-form,cob-map{visibility:hidden}.hydrated{visibility:inherit}</style><script type="text/javascript" src="./CoronavirusDiseaseinBoston.gov_files/06206dff86"></script><script type="text/javascript" async="" src="./CoronavirusDiseaseinBoston.gov_files/analytics.js"></script><script src="./CoronavirusDiseaseinBoston.gov_files/nr-1167.min.js"></script><script src="./CoronavirusDiseaseinBoston.gov_files/gtm.js" async=""></script><script type="text/javascript">(window.NREUM||(NREUM={})).loader_config={licenseKey:"06206dff86",applicationID:"449797348"};window.NREUM||(NREUM={}),__nr_require=function(e,n,t){function r(t){if(!n[t]){var i=n[t]={exports:{}};e[t][0].call(i.exports,function(n){var i=e[t][1][n];return r(i||n)},i,i.exports)}return n[t].exports}if("function"==typeof __nr_require)return __nr_require;for(var i=0;i<t.length;i++)r(t[i]);return r}({1:[function(e,n,t){function r(){}function i(e,n,t){return function(){return o(e,[u.now()].concat(f(arguments)),n?null:this,t),n?void 0:this}}var o=e("handle"),a=e(4),f=e(5),c=e("ee").get("tracer"),u=e("loader"),s=NREUM;"undefined"==typeof window.newrelic&&(newrelic=s);var p=["setPageViewName","setCustomAttribute","setErrorHandler","finished","addToTrace","inlineHit","addRelease"],l="api-",d=l+"ixn-";a(p,function(e,n){s[n]=i(l+n,!0,"api")}),s.addPageAction=i(l+"addPageAction",!0),s.setCurrentRouteName=i(l+"routeName",!0),n.exports=newrelic,s.interaction=function(){return(new r).get()};var m=r.prototype={createTracer:function(e,n){var t={},r=this,i="function"==typeof n;return o(d+"tracer",[u.now(),e,t],r),function(){if(c.emit((i?"":"no-")+"fn-start",[u.now(),r,i],t),i)try{return n.apply(this,arguments)}catch(e){throw c.emit("fn-err",[arguments,this,e],t),e}finally{c.emit("fn-end",[u.now()],t)}}}};a("actionText,setName,setAttribute,save,ignore,onEnd,getContext,end,get".split(","),function(e,n){m[n]=i(d+n)}),newrelic.noticeError=function(e,n){"string"==typeof e&&(e=new Error(e)),o("err",[e,u.now(),!1,n])}},{}],2:[function(e,n,t){function r(e,n){var t=e.getEntries();t.forEach(function(e){"first-paint"===e.name?c("timing",["fp",Math.floor(e.startTime)]):"first-contentful-paint"===e.name&&c("timing",["fcp",Math.floor(e.startTime)])})}function i(e,n){var t=e.getEntries();t.length>0&&c("lcp",[t[t.length-1]])}function o(e){if(e instanceof s&&!l){var n,t=Math.round(e.timeStamp);n=t>1e12?Date.now()-t:u.now()-t,l=!0,c("timing",["fi",t,{type:e.type,fid:n}])}}if(!("init"in NREUM&&"page_view_timing"in NREUM.init&&"enabled"in NREUM.init.page_view_timing&&NREUM.init.page_view_timing.enabled===!1)){var a,f,c=e("handle"),u=e("loader"),s=NREUM.o.EV;if("PerformanceObserver"in window&&"function"==typeof window.PerformanceObserver){a=new PerformanceObserver(r),f=new PerformanceObserver(i);try{a.observe({entryTypes:["paint"]}),f.observe({entryTypes:["largest-contentful-paint"]})}catch(p){}}if("addEventListener"in document){var l=!1,d=["click","keydown","mousedown","pointerdown","touchstart"];d.forEach(function(e){document.addEventListener(e,o,!1)})}}},{}],3:[function(e,n,t){function r(e,n){if(!i)return!1;if(e!==i)return!1;if(!n)return!0;if(!o)return!1;for(var t=o.split("."),r=n.split("."),a=0;a<r.length;a++)if(r[a]!==t[a])return!1;return!0}var i=null,o=null,a=/Version\/(\S+)\s+Safari/;if(navigator.userAgent){var f=navigator.userAgent,c=f.match(a);c&&f.indexOf("Chrome")===-1&&f.indexOf("Chromium")===-1&&(i="Safari",o=c[1])}n.exports={agent:i,version:o,match:r}},{}],4:[function(e,n,t){function r(e,n){var t=[],r="",o=0;for(r in e)i.call(e,r)&&(t[o]=n(r,e[r]),o+=1);return t}var i=Object.prototype.hasOwnProperty;n.exports=r},{}],5:[function(e,n,t){function r(e,n,t){n||(n=0),"undefined"==typeof t&&(t=e?e.length:0);for(var r=-1,i=t-n||0,o=Array(i<0?0:i);++r<i;)o[r]=e[n+r];return o}n.exports=r},{}],6:[function(e,n,t){n.exports={exists:"undefined"!=typeof window.performance&&window.performance.timing&&"undefined"!=typeof window.performance.timing.navigationStart}},{}],ee:[function(e,n,t){function r(){}function i(e){function n(e){return e&&e instanceof r?e:e?c(e,f,o):o()}function t(t,r,i,o){if(!l.aborted||o){e&&e(t,r,i);for(var a=n(i),f=v(t),c=f.length,u=0;u<c;u++)f[u].apply(a,r);var p=s[y[t]];return p&&p.push([b,t,r,a]),a}}function d(e,n){h[e]=v(e).concat(n)}function m(e,n){var t=h[e];if(t)for(var r=0;r<t.length;r++)t[r]===n&&t.splice(r,1)}function v(e){return h[e]||[]}function g(e){return p[e]=p[e]||i(t)}function w(e,n){u(e,function(e,t){n=n||"feature",y[t]=n,n in s||(s[n]=[])})}var h={},y={},b={on:d,addEventListener:d,removeEventListener:m,emit:t,get:g,listeners:v,context:n,buffer:w,abort:a,aborted:!1};return b}function o(){return new r}function a(){(s.api||s.feature)&&(l.aborted=!0,s=l.backlog={})}var f="nr@context",c=e("gos"),u=e(4),s={},p={},l=n.exports=i();l.backlog=s},{}],gos:[function(e,n,t){function r(e,n,t){if(i.call(e,n))return e[n];var r=t();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(e,n,{value:r,writable:!0,enumerable:!1}),r}catch(o){}return e[n]=r,r}var i=Object.prototype.hasOwnProperty;n.exports=r},{}],handle:[function(e,n,t){function r(e,n,t,r){i.buffer([e],r),i.emit(e,n,t)}var i=e("ee").get("handle");n.exports=r,r.ee=i},{}],id:[function(e,n,t){function r(e){var n=typeof e;return!e||"object"!==n&&"function"!==n?-1:e===window?0:a(e,o,function(){return i++})}var i=1,o="nr@id",a=e("gos");n.exports=r},{}],loader:[function(e,n,t){function r(){if(!x++){var e=E.info=NREUM.info,n=d.getElementsByTagName("script")[0];if(setTimeout(s.abort,3e4),!(e&&e.licenseKey&&e.applicationID&&n))return s.abort();u(y,function(n,t){e[n]||(e[n]=t)}),c("mark",["onload",a()+E.offset],null,"api");var t=d.createElement("script");t.src="https://"+e.agent,n.parentNode.insertBefore(t,n)}}function i(){"complete"===d.readyState&&o()}function o(){c("mark",["domContent",a()+E.offset],null,"api")}function a(){return O.exists&&performance.now?Math.round(performance.now()):(f=Math.max((new Date).getTime(),f))-E.offset}var f=(new Date).getTime(),c=e("handle"),u=e(4),s=e("ee"),p=e(3),l=window,d=l.document,m="addEventListener",v="attachEvent",g=l.XMLHttpRequest,w=g&&g.prototype;NREUM.o={ST:setTimeout,SI:l.setImmediate,CT:clearTimeout,XHR:g,REQ:l.Request,EV:l.Event,PR:l.Promise,MO:l.MutationObserver};var h=""+location,y={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net",agent:"js-agent.newrelic.com/nr-1167.min.js"},b=g&&w&&w[m]&&!/CriOS/.test(navigator.userAgent),E=n.exports={offset:f,now:a,origin:h,features:{},xhrWrappable:b,userAgent:p};e(1),e(2),d[m]?(d[m]("DOMContentLoaded",o,!1),l[m]("load",r,!1)):(d[v]("onreadystatechange",i),l[v]("onload",r)),c("mark",["firstbyte",f],null,"api");var x=0,O=e(6)},{}],"wrap-function":[function(e,n,t){function r(e){return!(e&&e instanceof Function&&e.apply&&!e[a])}var i=e("ee"),o=e(5),a="nr@original",f=Object.prototype.hasOwnProperty,c=!1;n.exports=function(e,n){function t(e,n,t,i){function nrWrapper(){var r,a,f,c;try{a=this,r=o(arguments),f="function"==typeof t?t(r,a):t||{}}catch(u){l([u,"",[r,a,i],f])}s(n+"start",[r,a,i],f);try{return c=e.apply(a,r)}catch(p){throw s(n+"err",[r,a,p],f),p}finally{s(n+"end",[r,a,c],f)}}return r(e)?e:(n||(n=""),nrWrapper[a]=e,p(e,nrWrapper),nrWrapper)}function u(e,n,i,o){i||(i="");var a,f,c,u="-"===i.charAt(0);for(c=0;c<n.length;c++)f=n[c],a=e[f],r(a)||(e[f]=t(a,u?f+i:i,o,f))}function s(t,r,i){if(!c||n){var o=c;c=!0;try{e.emit(t,r,i,n)}catch(a){l([a,t,r,i])}c=o}}function p(e,n){if(Object.defineProperty&&Object.keys)try{var t=Object.keys(e);return t.forEach(function(t){Object.defineProperty(n,t,{get:function(){return e[t]},set:function(n){return e[t]=n,n}})}),n}catch(r){l([r])}for(var i in e)f.call(e,i)&&(n[i]=e[i]);return n}function l(n){try{e.emit("internal-error",n)}catch(t){}}return e||(e=i),t.inPlace=u,t.flag=a,t}},{}]},{},["loader"]);</script>
+<link rel="canonical" href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston">
+<meta name="twitter:card" content="summary">
+<meta property="og:site_name" content="Boston.gov">
+<link rel="shortlink" href="https://www.boston.gov/node/11561926">
+<meta name="twitter:site" content="@CityOfBoston">
+<meta name="description" content="Information is rapidly changing — we will update this page as new and relevant information becomes available.">
+<meta name="twitter:title" content="Coronavirus Disease (COVID-19) in Boston">
+<meta name="twitter:description" content="Information is rapidly changing — we will update this page as new and relevant information becomes available.">
+<meta property="og:type" content="Article">
+<meta property="og:url" content="https://www.boston.gov/news/coronavirus-disease-covid-19-boston">
+<meta name="twitter:site:id" content="124455872">
+<meta property="og:title" content="Coronavirus Disease (COVID-19) in Boston">
+<meta name="generator" content="Drupal 8 (http://drupal.org)">
+<meta name="twitter:creator:id" content="124455872">
+<meta name="twitter:creator" content="@CityOfBoston">
+<meta property="og:description" content="Information is rapidly changing — we will update this page as new and relevant information becomes available.">
+<meta property="og:image" content="https://patterns.boston.gov/images/global/icons/seal_dark_1000x1000.png">
+<meta property="og:image:url" content="https://patterns.boston.gov/images/global/icons/seal_dark_1000x1000.png">
+<meta property="og:image:secure_url" content="https://patterns.boston.gov/images/global/icons/seal_dark_1000x1000.png">
+<link rel="apple-touch-icon" sizes="180x180" href="https://www.boston.gov/themes/custom/bos_theme/images/apple-touch-icon.png">
+<meta property="og:updated_time" content="2020-04-25T16:01:33-04:00">
+<link rel="apple-touch-icon-precomposed" sizes="180x180" href="https://www.boston.gov/themes/custom/bos_theme/images/apple-touch-icon-precomposed.png">
+<meta property="article:published_time" content="2020-02-05T09:48:28-05:00">
+<meta property="article:modified_time" content="2020-02-05T09:48:28-05:00">
+<meta name="Generator" content="Drupal 8 (https://www.drupal.org)">
+<meta name="MobileOptimized" content="width">
+<meta name="HandheldFriendly" content="true">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@graph": [
+        {
+            "@type": "ImageObject",
+            "url": "https://patterns.boston.gov/images/global/icons/b-logo-large.png"
+        }
+    ]
+}</script>
+<meta class="swiftype" name="site-priority" data-type="integer" content="5">
+<meta class="swiftype" name="type" data-type="enum" content="post">
+<link rel="shortcut icon" href="https://www.boston.gov/themes/custom/bos_theme/images/favicon.ico" type="image/vnd.microsoft.icon">
+<link rel="alternate" hreflang="en" href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston">
+<link rel="revision" href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston">
+<script src="./CoronavirusDiseaseinBoston.gov_files/google_tag.script.js" defer=""></script>
+<style>.ph-p-1 {background-image: url(https://www.boston.gov/sites/default/files/styles/photo_bleed_a_mobile_1x/public/img/library/photos/2020/03/walsh-coronavirus.jpg?itok=GFeE9whv);
+    background-size: cover !important;}
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .ph-p-1 { background-image: url(https://www.boston.gov/sites/default/files/styles/photo_bleed_b_tablet_1x/public/img/library/photos/2020/03/walsh-coronavirus.jpg?itok=rEQbIrlR); } }
+@media screen and (min-width: 0px) and (max-width: 419px) {
+    .ph-p-1 { background-image: url(https://www.boston.gov/sites/default/files/styles/photo_bleed_a_mobile_1x/public/img/library/photos/2020/03/walsh-coronavirus.jpg?itok=GFeE9whv); } }
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 2) {
+    .ph-p-1 { background-image: url(https://www.boston.gov/sites/default/files/styles/photo_bleed_c_desktop_1x/public/img/library/photos/2020/03/walsh-coronavirus.jpg?itok=LD8AtxxF); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .ph-p-1 { background-image: url(https://www.boston.gov/sites/default/files/styles/photo_bleed_c_desktop_1x/public/img/library/photos/2020/03/walsh-coronavirus.jpg?itok=LD8AtxxF); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) {
+    .ph-p-1 { background-image: url(https://www.boston.gov/sites/default/files/styles/photo_bleed_b_tablet_1x/public/img/library/photos/2020/03/walsh-coronavirus.jpg?itok=rEQbIrlR); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 2) {
+    .ph-p-1 { background-image: url(https://www.boston.gov/sites/default/files/styles/photo_bleed_d_large_1x/public/img/library/photos/2020/03/walsh-coronavirus.jpg?itok=vF8ZD5s4); } }
+@media screen and (min-width: 768px) and (max-width: 1439px) {
+    .ph-p-1 { background-image: url(https://www.boston.gov/sites/default/files/styles/photo_bleed_c_desktop_1x/public/img/library/photos/2020/03/walsh-coronavirus.jpg?itok=LD8AtxxF); } }
+@media screen and (min-width: 1440px) and (max-width: 1919px) {
+    .ph-p-1 { background-image: url(https://www.boston.gov/sites/default/files/styles/photo_bleed_d_large_1x/public/img/library/photos/2020/03/walsh-coronavirus.jpg?itok=vF8ZD5s4); } }
+@media screen and (min-width: 1920px) {
+    .ph-p-1 { background-image: url(https://www.boston.gov/sites/default/files/styles/photo_bleed_e_oversize_1x/public/img/library/photos/2020/03/walsh-coronavirus.jpg?itok=LFgzv50K); } }</style>
+<style>.cd-ic-421901 {background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.35.32%20AM.png?itok=sqniWTU2);
+    background-size: cover !important;}
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-421901 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.35.32%20AM.png?itok=ySy7Fm9z); } }
+@media screen and (min-width: 0px) and (max-width: 419px) {
+    .cd-ic-421901 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_a_mobile/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.35.32%20AM.png?itok=syiB9ntf); } }
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-421901 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.35.32%20AM.png?itok=_0-zqSZI); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-421901 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.35.32%20AM.png?itok=_0-zqSZI); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) {
+    .cd-ic-421901 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.35.32%20AM.png?itok=ySy7Fm9z); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-421901 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.35.32%20AM.png?itok=_0-zqSZI); } }
+@media screen and (min-width: 768px) and (max-width: 839px) {
+    .cd-ic-421901 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.35.32%20AM.png?itok=_0-zqSZI); } }
+@media screen and (min-width: 840px) and (max-width: 1439px) {
+    .cd-ic-421901 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.35.32%20AM.png?itok=sqniWTU2); } }
+@media screen and (min-width: 1440px) and (max-width: 1919px) {
+    .cd-ic-421901 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.35.32%20AM.png?itok=sqniWTU2); } }
+@media screen and (min-width: 1920px) {
+    .cd-ic-421901 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.35.32%20AM.png?itok=sqniWTU2); } }</style>
+<style>.cd-ic-421891 {background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.36.40%20AM.png?itok=8G_D1-tK);
+    background-size: cover !important;}
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-421891 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.36.40%20AM.png?itok=ZrhG8zjY); } }
+@media screen and (min-width: 0px) and (max-width: 419px) {
+    .cd-ic-421891 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_a_mobile/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.36.40%20AM.png?itok=8aK8b063); } }
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-421891 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.36.40%20AM.png?itok=g_T82K7o); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-421891 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.36.40%20AM.png?itok=g_T82K7o); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) {
+    .cd-ic-421891 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.36.40%20AM.png?itok=ZrhG8zjY); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-421891 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.36.40%20AM.png?itok=g_T82K7o); } }
+@media screen and (min-width: 768px) and (max-width: 839px) {
+    .cd-ic-421891 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.36.40%20AM.png?itok=g_T82K7o); } }
+@media screen and (min-width: 840px) and (max-width: 1439px) {
+    .cd-ic-421891 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.36.40%20AM.png?itok=8G_D1-tK); } }
+@media screen and (min-width: 1440px) and (max-width: 1919px) {
+    .cd-ic-421891 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.36.40%20AM.png?itok=8G_D1-tK); } }
+@media screen and (min-width: 1920px) {
+    .cd-ic-421891 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-18%20at%2010.36.40%20AM.png?itok=8G_D1-tK); } }</style>
+<style>.cd-ic-422126 {background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-20%20at%202.45.17%20PM.png?itok=1HHMui4-);
+    background-size: cover !important;}
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-422126 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/Screen%20Shot%202020-04-20%20at%202.45.17%20PM.png?itok=AqfBRAcT); } }
+@media screen and (min-width: 0px) and (max-width: 419px) {
+    .cd-ic-422126 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_a_mobile/public/img/library/photos/2020/04/Screen%20Shot%202020-04-20%20at%202.45.17%20PM.png?itok=vWO6W0VV); } }
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-422126 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-20%20at%202.45.17%20PM.png?itok=M8Amf0h1); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-422126 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-20%20at%202.45.17%20PM.png?itok=M8Amf0h1); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) {
+    .cd-ic-422126 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/Screen%20Shot%202020-04-20%20at%202.45.17%20PM.png?itok=AqfBRAcT); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-422126 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-20%20at%202.45.17%20PM.png?itok=M8Amf0h1); } }
+@media screen and (min-width: 768px) and (max-width: 839px) {
+    .cd-ic-422126 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-20%20at%202.45.17%20PM.png?itok=M8Amf0h1); } }
+@media screen and (min-width: 840px) and (max-width: 1439px) {
+    .cd-ic-422126 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-20%20at%202.45.17%20PM.png?itok=1HHMui4-); } }
+@media screen and (min-width: 1440px) and (max-width: 1919px) {
+    .cd-ic-422126 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-20%20at%202.45.17%20PM.png?itok=1HHMui4-); } }
+@media screen and (min-width: 1920px) {
+    .cd-ic-422126 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-20%20at%202.45.17%20PM.png?itok=1HHMui4-); } }</style>
+<style>.cd-ic-415861 {background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-04%20at%204.22.05%20PM.png?itok=fiyvysFs);
+    background-size: cover !important;}
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-415861 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/Screen%20Shot%202020-04-04%20at%204.22.05%20PM.png?itok=M9s0bhIl); } }
+@media screen and (min-width: 0px) and (max-width: 419px) {
+    .cd-ic-415861 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_a_mobile/public/img/library/photos/2020/04/Screen%20Shot%202020-04-04%20at%204.22.05%20PM.png?itok=EJKH0WQM); } }
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-415861 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-04%20at%204.22.05%20PM.png?itok=jIqMP_Fv); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-415861 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-04%20at%204.22.05%20PM.png?itok=jIqMP_Fv); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) {
+    .cd-ic-415861 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/Screen%20Shot%202020-04-04%20at%204.22.05%20PM.png?itok=M9s0bhIl); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-415861 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-04%20at%204.22.05%20PM.png?itok=jIqMP_Fv); } }
+@media screen and (min-width: 768px) and (max-width: 839px) {
+    .cd-ic-415861 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/Screen%20Shot%202020-04-04%20at%204.22.05%20PM.png?itok=jIqMP_Fv); } }
+@media screen and (min-width: 840px) and (max-width: 1439px) {
+    .cd-ic-415861 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-04%20at%204.22.05%20PM.png?itok=fiyvysFs); } }
+@media screen and (min-width: 1440px) and (max-width: 1919px) {
+    .cd-ic-415861 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-04%20at%204.22.05%20PM.png?itok=fiyvysFs); } }
+@media screen and (min-width: 1920px) {
+    .cd-ic-415861 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/Screen%20Shot%202020-04-04%20at%204.22.05%20PM.png?itok=fiyvysFs); } }</style>
+<style>.cd-ic-415851 {background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/program/intro_images/2019/10/resident-parking-intro.jpg?itok=OuY1Waet);
+    background-size: cover !important;}
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-415851 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/program/intro_images/2019/10/resident-parking-intro.jpg?itok=D3Yo7a39); } }
+@media screen and (min-width: 0px) and (max-width: 419px) {
+    .cd-ic-415851 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_a_mobile/public/img/program/intro_images/2019/10/resident-parking-intro.jpg?itok=dRgps6xO); } }
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-415851 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/program/intro_images/2019/10/resident-parking-intro.jpg?itok=kYN99hwO); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-415851 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/program/intro_images/2019/10/resident-parking-intro.jpg?itok=kYN99hwO); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) {
+    .cd-ic-415851 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/program/intro_images/2019/10/resident-parking-intro.jpg?itok=D3Yo7a39); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-415851 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/program/intro_images/2019/10/resident-parking-intro.jpg?itok=kYN99hwO); } }
+@media screen and (min-width: 768px) and (max-width: 839px) {
+    .cd-ic-415851 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/program/intro_images/2019/10/resident-parking-intro.jpg?itok=kYN99hwO); } }
+@media screen and (min-width: 840px) and (max-width: 1439px) {
+    .cd-ic-415851 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/program/intro_images/2019/10/resident-parking-intro.jpg?itok=OuY1Waet); } }
+@media screen and (min-width: 1440px) and (max-width: 1919px) {
+    .cd-ic-415851 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/program/intro_images/2019/10/resident-parking-intro.jpg?itok=OuY1Waet); } }
+@media screen and (min-width: 1920px) {
+    .cd-ic-415851 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/program/intro_images/2019/10/resident-parking-intro.jpg?itok=OuY1Waet); } }</style>
+<style>.cd-ic-415841 {background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/meal-sites.jpg?itok=icPSTmjl);
+    background-size: cover !important;}
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-415841 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/meal-sites.jpg?itok=oIOEK5Gq); } }
+@media screen and (min-width: 0px) and (max-width: 419px) {
+    .cd-ic-415841 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_a_mobile/public/img/library/photos/2020/04/meal-sites.jpg?itok=La1xlply); } }
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-415841 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/meal-sites.jpg?itok=tyg4k3sv); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-415841 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/meal-sites.jpg?itok=tyg4k3sv); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) {
+    .cd-ic-415841 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/meal-sites.jpg?itok=oIOEK5Gq); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-415841 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/meal-sites.jpg?itok=tyg4k3sv); } }
+@media screen and (min-width: 768px) and (max-width: 839px) {
+    .cd-ic-415841 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/meal-sites.jpg?itok=tyg4k3sv); } }
+@media screen and (min-width: 840px) and (max-width: 1439px) {
+    .cd-ic-415841 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/meal-sites.jpg?itok=icPSTmjl); } }
+@media screen and (min-width: 1440px) and (max-width: 1919px) {
+    .cd-ic-415841 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/meal-sites.jpg?itok=icPSTmjl); } }
+@media screen and (min-width: 1920px) {
+    .cd-ic-415841 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/meal-sites.jpg?itok=icPSTmjl); } }</style>
+<style>.cd-ic-415396 {background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/artist-relief.jpg?itok=mV9HVlhs);
+    background-size: cover !important;}
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-415396 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/artist-relief.jpg?itok=ttQz40WA); } }
+@media screen and (min-width: 0px) and (max-width: 419px) {
+    .cd-ic-415396 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_a_mobile/public/img/library/photos/2020/04/artist-relief.jpg?itok=iYRHnCRC); } }
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-415396 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/artist-relief.jpg?itok=JbSegV8c); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-415396 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/artist-relief.jpg?itok=JbSegV8c); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) {
+    .cd-ic-415396 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/artist-relief.jpg?itok=ttQz40WA); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-415396 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/artist-relief.jpg?itok=JbSegV8c); } }
+@media screen and (min-width: 768px) and (max-width: 839px) {
+    .cd-ic-415396 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/artist-relief.jpg?itok=JbSegV8c); } }
+@media screen and (min-width: 840px) and (max-width: 1439px) {
+    .cd-ic-415396 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/artist-relief.jpg?itok=mV9HVlhs); } }
+@media screen and (min-width: 1440px) and (max-width: 1919px) {
+    .cd-ic-415396 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/artist-relief.jpg?itok=mV9HVlhs); } }
+@media screen and (min-width: 1920px) {
+    .cd-ic-415396 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/artist-relief.jpg?itok=mV9HVlhs); } }</style>
+<style>.cd-ic-415491 {background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/small-biz-fund.jpg?itok=5-VWvxR7);
+    background-size: cover !important;}
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-415491 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/small-biz-fund.jpg?itok=1F6XQfIL); } }
+@media screen and (min-width: 0px) and (max-width: 419px) {
+    .cd-ic-415491 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_a_mobile/public/img/library/photos/2020/04/small-biz-fund.jpg?itok=aigS0oYx); } }
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-415491 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/small-biz-fund.jpg?itok=KEMXytFb); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-415491 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/small-biz-fund.jpg?itok=KEMXytFb); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) {
+    .cd-ic-415491 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/small-biz-fund.jpg?itok=1F6XQfIL); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-415491 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/small-biz-fund.jpg?itok=KEMXytFb); } }
+@media screen and (min-width: 768px) and (max-width: 839px) {
+    .cd-ic-415491 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/small-biz-fund.jpg?itok=KEMXytFb); } }
+@media screen and (min-width: 840px) and (max-width: 1439px) {
+    .cd-ic-415491 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/small-biz-fund.jpg?itok=5-VWvxR7); } }
+@media screen and (min-width: 1440px) and (max-width: 1919px) {
+    .cd-ic-415491 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/small-biz-fund.jpg?itok=5-VWvxR7); } }
+@media screen and (min-width: 1920px) {
+    .cd-ic-415491 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/small-biz-fund.jpg?itok=5-VWvxR7); } }</style>
+<style>.cd-ic-415481 {background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/PA150306.jpg?itok=aDOPhfk8);
+    background-size: cover !important;}
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-415481 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/PA150306.jpg?itok=c7BIKNCQ); } }
+@media screen and (min-width: 0px) and (max-width: 419px) {
+    .cd-ic-415481 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_a_mobile/public/img/library/photos/2020/04/PA150306.jpg?itok=k_k8R3w8); } }
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-415481 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/PA150306.jpg?itok=1_k27vDY); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-415481 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/PA150306.jpg?itok=1_k27vDY); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) {
+    .cd-ic-415481 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/library/photos/2020/04/PA150306.jpg?itok=c7BIKNCQ); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-415481 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/PA150306.jpg?itok=1_k27vDY); } }
+@media screen and (min-width: 768px) and (max-width: 839px) {
+    .cd-ic-415481 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/library/photos/2020/04/PA150306.jpg?itok=1_k27vDY); } }
+@media screen and (min-width: 840px) and (max-width: 1439px) {
+    .cd-ic-415481 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/PA150306.jpg?itok=aDOPhfk8); } }
+@media screen and (min-width: 1440px) and (max-width: 1919px) {
+    .cd-ic-415481 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/PA150306.jpg?itok=aDOPhfk8); } }
+@media screen and (min-width: 1920px) {
+    .cd-ic-415481 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/library/photos/2020/04/PA150306.jpg?itok=aDOPhfk8); } }</style>
+<style>.cd-ic-415386 {background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=wPUzjIt3);
+    background-size: cover !important;}
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-415386 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=PmDt9wYY); } }
+@media screen and (min-width: 0px) and (max-width: 419px) {
+    .cd-ic-415386 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_a_mobile/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=zYFowv0D); } }
+@media screen and (min-width: 0px) and (max-width: 419px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-415386 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=XYVMBM0K); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 1.5) {
+    .cd-ic-415386 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=XYVMBM0K); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) {
+    .cd-ic-415386 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_b_tablet/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=PmDt9wYY); } }
+@media screen and (min-width: 420px)  and (max-width: 767px) and (-webkit-min-device-pixel-ratio: 2) {
+    .cd-ic-415386 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=XYVMBM0K); } }
+@media screen and (min-width: 768px) and (max-width: 839px) {
+    .cd-ic-415386 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_vertical_c_desktop/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=XYVMBM0K); } }
+@media screen and (min-width: 840px) and (max-width: 1439px) {
+    .cd-ic-415386 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=wPUzjIt3); } }
+@media screen and (min-width: 1440px) and (max-width: 1919px) {
+    .cd-ic-415386 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=wPUzjIt3); } }
+@media screen and (min-width: 1920px) {
+    .cd-ic-415386 { background-image: url(https://www.boston.gov/sites/default/files/styles/card_grid_horizontal_e_oversize/public/img/program/intro_images/2017/05/city-hall-pic.jpg?itok=wPUzjIt3); } }</style>
+
+    <title>Coronavirus Disease (COVID-19) in Boston | Boston.gov</title>
+    <link rel="stylesheet" media="all" href="./CoronavirusDiseaseinBoston.gov_files/css_2kmXq0qcJUvSz-fhEtKksclehFEsjhYu8bvwsNzgmCk.css">
+
+<!--[if lte IE 9]><!-->
+<link rel="stylesheet" media="all" href="./CoronavirusDiseaseinBoston.gov_files/public.css">
+<!--<![endif]-->
+
+<!--[if lte IE 9]><!-->
+<link rel="stylesheet" media="all" href="./CoronavirusDiseaseinBoston.gov_files/public(1).css">
+<!--<![endif]-->
+<link rel="stylesheet" media="all" href="./CoronavirusDiseaseinBoston.gov_files/css_6oJnxXTl5t9fkw3C8uMRtGxwbWXLDmLm2glpmOsBgVY.css">
+
+<!--[if lt IE 10]>
+<link rel="stylesheet" media="all" href="https://patterns.boston.gov/css/ie.css" />
+<![endif]-->
+
+    
+<!--[if lte IE 8]>
+<script src="/sites/default/files/js/js_VtafjXmRvoUgAzqzYTA3Wrjkx9wcWhjP0G4ZnnqRamA.js"></script>
+<![endif]-->
+<script src="./CoronavirusDiseaseinBoston.gov_files/modernizr.min.js"></script>
+
+  <script src="./CoronavirusDiseaseinBoston.gov_files/fleetcomponents.ip6retou.js" type="module" crossorigin="true" data-resources-url="https://patterns.boston.gov/web-components/fleetcomponents/" data-namespace="fleetcomponents"></script></head>
+  <body class="html bos_theme not-front not-logged-in node-published page-node-11561926 page-node node-type-post">
+          <p class="skip-link__wrapper" data-swiftype-index="false">
+        <a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#main-menu" class="skip-link visually-hidden--focusable" id="skip-link" tabindex="-1">Jump to navigation</a>
+      </p>
+    
+    <noscript aria-hidden="true"><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TKGRDS" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      <div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas="">
+    
+<input type="checkbox" id="brg-tr" class="brg-tr" aria-hidden="true">
+
+<nav class="nv-m">
+  <div class="nv-m-h">
+    <div class="nv-m-h-ic">
+      <a href="https://www.boston.gov/" title="Go to home page">
+        <img src="./CoronavirusDiseaseinBoston.gov_files/b-dark.svg" alt="City of Boston" aria-hidden="true" class="nv-m-h-i">
+      </a>
+    </div>
+    <div id="nv-m-h-t" class="nv-m-h-t">&nbsp;</div>
+  </div>
+  <div class="nv-m-c">
+    <nav role="navigation" aria-labelledby="block-mainmenu-menu" id="block-mainmenu" data-block-plugin-id="menu_block:main">
+            
+  <h2 class="visually-hidden" id="block-mainmenu-menu">Main menu</h2>
+  
+
+        
+
+                            <ul class="nv-m-c-l">
+                                                                  <li class="nv-m-c-l-i is-l leaf first menu-mlid-763366 nv-m-c-a--y">
+                            <a href="http://www.cityofboston.gov/311/" title="" class="nv-m-c-a mv-m-c-a--p three-one-one">Help / 311</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-i is-l leaf menu-mlid-210101">
+                            <a href="https://www.boston.gov/homepage" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/21">Home</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-i is-l leaf menu-mlid-171721">
+                            <a href="https://www.boston.gov/guides" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/841">Guides to Boston</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-i is-l leaf menu-mlid-171726">
+                            <a href="https://www.boston.gov/departments" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/1796">Departments</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-i is-l leaf menu-mlid-1675906">
+                            <a href="https://www.boston.gov/public-notices" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/11666">Public Notices</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-i is-l leaf menu-mlid-2354776">
+                            <a href="https://www.boston.gov/pay-and-apply" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/32906">Pay and apply</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-i is-l leaf menu-mlid-2354781">
+                            <a href="https://www.boston.gov/career-center" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/19261">Work for the City</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-i is-l leaf menu-mlid-885866">
+                            <a href="https://www.boston.gov/events" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/1426">Events</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-i is-l leaf menu-mlid-202946">
+                            <a href="https://www.boston.gov/news" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/1401">News</a>
+                            </li>
+                                                          <li class="nv-m-c-l-i is-e expanded menu-mlid-171731">
+                <a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#" title="" class="nv-m-c-a mv-m-c-a--p nolink nolink--a">Places</a>                  
+                                                              <ul class="nv-m-c-l-l nv-m-c-l-l--h">
+            <li class="nv-m-c-bc"><button class="nv-m-c-b">Back</button></li>
+                                                                  <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/cemeteries" title="" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/33006">Cemeteries</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/community-centers" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/32886">Community centers</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/departments/landmarks-commission#historic-districts" title="" class="nv-m-c-a mv-m-c-a--p">Historic Districts</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.bpl.org/" title="" class="nv-m-c-a mv-m-c-a--p">Libraries</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/neighborhoods" title="" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/33066">Neighborhoods</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/parks-and-playgrounds" title="" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/32946">Parks and playgrounds</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="http://www.bostonpublicschools.org/Page/628" title="" class="nv-m-c-a mv-m-c-a--p">Schools</a>
+                            </li>
+                            </ul>
+    
+                              </li>
+                                                          <li class="nv-m-c-l-i is-e expanded menu-mlid-171741 last">
+                <a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#" title="" class="nv-m-c-a mv-m-c-a--p nolink nolink--a">Government</a>                  
+                                                              <ul class="nv-m-c-l-l nv-m-c-l-l--h">
+            <li class="nv-m-c-bc"><button class="nv-m-c-b">Back</button></li>
+                                                                  <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/departments/mayors-office" title="" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/176">The Mayor's Office</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/departments/city-council" title="" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/91">City Council</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/departments/city-clerk" title="" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/136">City Clerk</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/departments/election" title="" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/131">Elections</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/civic-engagement/boards-and-commissions" title="" class="nv-m-c-a mv-m-c-a--p">Boards and commissions</a>
+                            </li>
+                                                                      <li class="nv-m-c-l-l-i is-l leaf ">
+                            <a href="https://www.boston.gov/departments/311/city-boston-government" class="nv-m-c-a mv-m-c-a--p" data-drupal-link-system-path="node/28101">City government</a>
+                            </li>
+                            </ul>
+    
+                              </li>
+                            </ul>
+    
+
+
+  </nav>
+
+
+  </div>
+</nav>
+
+<div id="page" class="mn page--wa" data-target="11561926">
+  <input type="checkbox" id="s-tr" class="s-tr" aria-hidden="true">
+
+  <header id="main-menu" class="h" role="banner" data-swiftype-index="false">
+    <label for="brg-tr" class="brg-b">
+  <div class="brg">
+    <span class="brg-c">
+      <span class="brg-c-i"></span>
+    </span>
+    <span class="brg-t"><span class="a11y--h">Toggle </span>Menu</span>
+  </div>
+</label>
+
+      <div class="lo lo--abs">
+    <div class="lo-l lo-b-cont">
+      <a href="https://www.boston.gov/">
+        <img src="./CoronavirusDiseaseinBoston.gov_files/logo.svg" alt="Boston.gov" class="lo-i">
+      </a>
+              <span class="lo-t"><a href="https://www.boston.gov/mayor">Mayor Martin J. Walsh</a></span>
+          </div>
+  </div>
+
+    <a id="seal" href="https://www.boston.gov/" title="Home" rel="home" class="s s--u">
+  <img src="./CoronavirusDiseaseinBoston.gov_files/seal.svg" alt="City of Boston Seal" class="s-i">
+</a>
+
+    <nav class="nv-h">
+    <ul class="nv-h-l">
+        
+        
+                    <li class="nv-h-l-i">
+                <a href="https://www.boston.gov/pay-and-apply" title="" class="nv-h-l-a" data-drupal-link-system-path="node/32906">Pay and apply</a>
+            </li>
+                    <li class="nv-h-l-i">
+                <a href="https://www.boston.gov/public-notices" title="" class="nv-h-l-a" data-drupal-link-system-path="node/11666">Public notices</a>
+            </li>
+                    <li class="nv-h-l-i">
+                <a href="mailto:311supervisors@boston.gov" title="" class="nv-h-l-a" data-modal="feedback">Feedback</a>
+            </li>
+                    <li class="tr nv-h-l-i tr-dd-link--hidden translate-dropdown-menu tr--visible">
+            <a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#translate" title="Translate" class="nv-h-l-a nv-h-l-a--k--s tr-link">Translate</a>
+            <ul class="tr-dd">
+                <li><span class="notranslate tr-dd-link tr-dd-link--message">Loading...</span></li>
+                <li><a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#" class="notranslate tr-dd-link" data-ln="ht">Kreyòl Ayisyen</a></li>
+                <li><a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#" class="notranslate tr-dd-link" data-ln="pt">Portugese</a></li>
+                <li><a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#" class="notranslate tr-dd-link" data-ln="es">Español</a></li>
+                <li><a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#" class="notranslate tr-dd-link" data-ln="vi">Tiếng Việt</a></li>
+                <li><a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#" class="notranslate tr-dd-link tr-dd-link--hidden" data-ln="en">English</a></li>
+            </ul>
+        </li>
+        <li class="nv-h-l-i">
+            <label for="s-tr" title="Search" class="nv-h-l-a nv-h-l-a--k nv-h-l-a-ic" id="searchIcon">
+                <svg id="Layer_2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 41"><title>Search</title>
+                    <path class="nv-h-l-a-i" d="M24.2.6C15.8.6 9 7.4 9 15.8c0 3.7 1.4 7.2 3.6 9.8L1.2 37c-.8.8-.8 2 0 2.8.4.4.9.6 1.4.6s1-.2 1.4-.6l11.5-11.5C18 30 21 31 24.2 31c8.4 0 15.2-6.8 15.2-15.2C39.4 7.4 32.6.6 24.2.6zm0 26.5c-6.2 0-11.2-5-11.2-11.2S18 4.6 24.2 4.6s11.2 5 11.2 11.2-5 11.3-11.2 11.3z"></path>
+                </svg>
+            </label>
+        </li>
+    </ul>
+</nav>
+
+    <div class="h-s">
+  <form class="sf" action="https://www.boston.gov/search" accept-charset="UTF-8" method="get">
+    <input name="utf8" type="hidden" value="✓">
+    <div class="sf-i">
+      <input type="text" name="query" id="query" value="" placeholder="Search…" class="sf-i-f" autocomplete="off">
+      <button class="sf-i-b">Search</button>
+    </div>
+  </form>
+</div>
+
+  </header>
+
+  
+
+  
+  <div class="main">
+    <div class="container">
+
+      <section class="main-content" id="content" role="main">
+        
+        <a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#skip-link" class="visually-hidden--focusable" id="main-content" data-swiftype-index="false" tabindex="-1">Back to top</a>
+
+       
+                
+
+        
+        
+        
+
+        
+              <div data-drupal-messages-fallback="" class="hidden"></div>
+
+  <div class="breadcrumb" data-swiftype-index="false">
+    <div data-block-plugin-id="system_breadcrumb_block">
+  
+    
+         <div id="breadcrumb" data-swiftype-index="false">
+      <nav class="brc" role="navigation" aria-labelledby="system-breadcrumb">
+         <div class="a11y--h"><span class="brc-t">You are here</span></div>
+         <ul class="brc-l">
+                           <li class="brc-l-i">
+                                       <a href="https://www.boston.gov/">Home</a>
+                                    <span class="brc-s">  ›  </span>
+               </li>
+                           <li class="brc-l-i">
+                                       <a href="https://www.boston.gov/news">Latest City of Boston news</a>
+                                    <span class="brc-s">  ›  </span>
+               </li>
+                        <li class="brc-l-i">
+               Coronavirus Disease (COVID-19) in Boston
+            </li>
+         </ul>
+      </nav>
+   </div>
+
+  </div>
+
+  </div>
+
+
+<article role="article" about="/news/coronavirus-disease-covid-19-boston" class="node-11561926 node clearfix node-post modstate-published desktop-100" bos_context_type="Post" id="node-11561926">
+  <div class="department-info-wrapper desktop-100">
+
+    
+
+          <h1>Coronavirus Disease (COVID-19) in Boston</h1>
+    
+    
+
+<!--
+    Do not add additional content to the following right column.
+    Secondary content should be included in a new right column below the left (main) column.
+ -->
+    <div class="column mobile-100 desktop-33-right">
+      <p class="published-by-date">
+                    <time datetime="2020-04-25T20:01:35Z">April 25, 2020</time>
+
+      
+      </p>
+      <div class="list-item detail-list-item published-by-detail">
+                    
+              <div class="post-contact">
+
+	<div class="department-icon left">
+		            <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 137 130"><title>public_health_commission_logo</title><g id="Layer_7" data-name="Layer 7"><g id="Layer_2" data-name="Layer 2"><g id="icons"><rect x="59.17" y="79.75" width="17" height="64.43" transform="translate(-45.48 177.64) rotate(-88.98)" fill="#ff454a"></rect><path d="M69.48,9.48,37.27,9l-.76,43.28C40.18,78.5,68.12,86,68.12,86S97,77,100.93,53.39l.76-43.28Z" fill="#091f2f"></path></g></g><path d="M53.88,66.91a27.1,27.1,0,0,0,4.67,5.22,44.66,44.66,0,0,0,5.72,4.29A67,67,0,0,0,70.92,80l0,0L71,80q-2.72-5.42-2.64-9.44a8.42,8.42,0,0,1,1.1-4,13,13,0,0,1,2.74-3.37c1.12-1,2.36-2,3.72-2.95s2.72-2,4.08-3.17a35.57,35.57,0,0,0,3.73-3.62,15.39,15.39,0,0,0,2.76-4.67,17.14,17.14,0,0,0,1.14-6h0a25,25,0,0,0-1-7.73,23.27,23.27,0,0,0-2.92-6.36,27.4,27.4,0,0,0-4.67-5.22,44.66,44.66,0,0,0-5.72-4.29,67,67,0,0,0-6.65-3.59l0,0-.13,0q2.67,5.49,2.6,9.43a8.42,8.42,0,0,1-1.1,4,13,13,0,0,1-2.74,3.37c-1.12,1-2.36,2-3.72,3s-2.72,2-4.08,3.17a34.68,34.68,0,0,0-3.73,3.63,15.34,15.34,0,0,0-2.76,4.66,17.19,17.19,0,0,0-1.14,6,24.94,24.94,0,0,0,1,7.72A23.27,23.27,0,0,0,53.88,66.91Z" fill="#fff"></path></g></svg>
+  </div>
+
+
+      
+  </article>
+
+      
+	</div>
+
+	<div class="contact-info right">
+		<p class="published-by">Published by:</p>
+	    <p class="department-title"><a href="https://www.boston.gov/departments/public-health-commission">Public Health Commission</a></p>
+	</div>
+
+	<div class="clearfix"></div>
+
+</div>
+
+      
+
+
+      
+      </div>
+    </div>
+
+    <div class="column mobile-100 desktop-66-left">
+
+         <div class="intro-text supporting-text squiggle-border-bottom field field-name-field-intro-text field-type-text-long intro-text supporting-text squiggle-border-bottom"><p>We will update this page&nbsp;as new and relevant COVID-19 information becomes available.</p>
+</div>
+
+
+              <div class="sub-nav-trigger drawer-trigger">
+          <div class="sub-nav-chevron">
+            <!--?xml version="1.0" encoding="utf-8"?-->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 26 18" style="enable-background:new 0 0 26 18;" xml:space="preserve">
+	 <title>Toggle</title>
+	 <path class="st0 icon-stroke" d="M13,17.7L0.5,2.7C0,2.1,0.1,1.2,0.7,0.6c0.6-0.5,1.6-0.4,2.1,0.2L13,13L23.2,0.8c0.5-0.6,1.5-0.7,2.1-0.2
+	c0.6,0.5,0.7,1.5,0.2,2.1L13,17.7z"></path>
+</svg>
+
+          </div>
+          Page Sections
+        </div>
+        <nav class="topic-nav topic-nav__left">
+          <a name="section-nav"></a>
+          <ul><li><a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#covid-19-info" class="scroll-link-js">COVID-19 info</a></li><li><a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#get-help" class="scroll-link-js">Get help</a></li><li><a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#relief-funds" class="scroll-link-js">Relief funds</a></li><li><a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#get-involved" class="scroll-link-js">Get involved</a></li><li><a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#maps-and-dashboards" class="scroll-link-js">Maps and dashboards</a></li><li><a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#multilingual-help" class="scroll-link-js">Multilingual help</a></li><li><a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#local-support" class="scroll-link-js">Local support</a></li><li><a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#latest-press-conference" class="scroll-link-js">Latest press conference</a></li><li><a href="https://www.boston.gov/news/coronavirus-disease-covid-19-boston#list-of-resources" class="scroll-link-js">List of resources</a></li></ul>
+        </nav>
+      
+          <div class="body field field-name-body field-type-text-with-summary field-label-hidden field-items">
+            <address><strong><span class="red">LATEST UPDATES:</span></strong></address>
+<ul><li>The City of Boston will now <a href="https://www.boston.gov/node/11566196">allow permitted restaurants to sell grocery items</a> via delivery, curbside pickup, and takeout by waiving the required Retail Food Permit for the sale of uncooked foods.</li>
+</ul><address><strong>What you need to know:</strong></address>
+<ul><li>Governor Baker announced the <a href="https://www.bostonpublicschools.org/coronavirus">closure of K-12 schools in Massachusetts</a>&nbsp;and non-emergency childcare programs through the end of the school year. We have&nbsp;<a href="https://www.boston.gov/node/11564416">free breakfast and lunch sites</a> across the City for youth and teens.</li>
+<li><a href="https://content.boston.gov/node/11565221" rel="nofollow">There are&nbsp;<em>s</em>trict new measures</a>&nbsp;in place for social and physical distancing for Boston residents through&nbsp;<strong>Monday, May 4, 2020</strong>, including<strong>&nbsp;</strong>encouraging everyone to <a href="https://www.boston.gov/node/11565286">wear a face covering</a>&nbsp;in public.</li>
+<li>A&nbsp;<a href="https://www.boston.gov/node/11565221">Public Health Advisory</a>&nbsp;is in place for everyone in Boston, except essential workers, to stay at home from 9 p.m. to 6 a.m. each day.</li>
+<li><a href="https://www.boston.gov/node/11564386">City parks with recreational sports areas are closed</a>, along with playgrounds and tot lots. Parks remain open for passive use.</li>
+<li>City Hall will only be open to the public&nbsp;on <a href="https://www.boston.gov/node/11564911">Tuesdays and Fridays, from 9 a.m. to 5 p.m.</a>&nbsp;If you need to visit City Hall for essential services, you must&nbsp;make an appointment.</li>
+<li><span><span>All&nbsp;<a href="https://www.bpl.org/news/covid-19-update/">Boston Public Library</a>&nbsp;locations and&nbsp;</span></span><a href="https://www.boston.gov/departments/boston-centers-youth-families">Boston Centers for Youth &amp; Families</a>&nbsp;pools, gyms, and fitness centers are closed.</li>
+<li>The City has&nbsp;suspended&nbsp;<a href="https://www.boston.gov/node/11564521">all regular activity at construction sites</a></li>
+<li><span><span>The&nbsp;MBTA&nbsp;has&nbsp;<a href="https://mbta.com/covid19">reduced its&nbsp;services</a>.</span></span></li>
+</ul><p>For more recent City of Boston&nbsp;updates,&nbsp;<a href="https://www.boston.gov/node/11564436">view our COVID-19 timeline</a>.</p>
+
+          </div>
+
+
+      
+
+    </div>
+
+    <div class="column mobile-100 desktop-33-right">
+              
+          <div class="list-item">
+      <div class="detail-item " bos_context_type="Sidebar Item">
+      <div class="detail-item__content">
+            <div class="detail-item__label ">
+         
+      </div>
+                     <div class="detail-item__body ">
+                               <div class="field field-name-field-sidebar-text field-type-text-long field-label-hidden field-items">
+                <div>
+        <h4>COVID-19 cases: by the numbers</h4>
+<address>Boston: 7,910&nbsp;confirmed&nbsp;cases (1,573&nbsp;recovered and 271&nbsp;deaths)</address>
+<p><em>Updated as of Saturday, April 25</em></p>
+<ul><li><a href="https://www.boston.gov/node/11565596"><em>Racial data on Boston cases</em></a></li>
+</ul><address>Massachusetts: 53,348&nbsp;confirmed cases</address>
+<p><em>Updated as of Saturday,&nbsp;April 25</em></p>
+
+            </div>
+          </div>
+
+                     </div>
+         </div>
+</div>
+    </div>
+  
+          <div class="list-item">
+      <div class="detail-item " bos_context_type="Sidebar Item">
+      <div class="detail-item__content">
+            <div class="detail-item__label ">
+         
+      </div>
+                     <div class="detail-item__body ">
+                               <div class="field field-name-field-sidebar-text field-type-text-long field-label-hidden field-items">
+                <div>
+        <p>Have questions? Contact:</p>
+<address><a href="https://bphc.org/onlinenewsroom/Blog/Lists/Posts/Post.aspx?ID=1282">Public Health Commission</a></address>
+
+            </div>
+          </div>
+
+                     </div>
+         </div>
+</div>
+    </div>
+  
+          <div class="list-item">
+      
+<div class="detail-item " bos_context_type="Sidebar Item W Icon">
+         <div class="detail-item__left">
+         <div class="icon icon-email"></div>
+      </div>
+      <div class="detail-item__content">
+            <div class="detail-item__label ">
+         
+      </div>
+                     <div class="detail-item__body ">
+                                       <address><a href="mailto:info@bphc.org" title="Have a question, or just need help? You can send an email to info@bphc.org through the form below.">INFO@BPHC.ORG</a></address>
+
+      
+                     </div>
+         </div>
+</div>
+    </div>
+  
+          <div class="list-item">
+      
+<div class="detail-item " bos_context_type="Sidebar Item W Icon">
+         <div class="detail-item__left">
+         <div class="icon icon-phone"></div>
+      </div>
+      <div class="detail-item__content">
+            <div class="detail-item__label ">
+         
+      </div>
+                     <div class="detail-item__body ">
+                                       <address><a href="tel:617-534-5050">617-534-5050</a></address>
+<address>Toll-Free: <a href="tel:1-800-847-0710">1-800-847-0710</a></address>
+
+      
+                     </div>
+         </div>
+</div>
+    </div>
+  
+          <div class="list-item">
+      <div class="detail-item " bos_context_type="Sidebar Item">
+      <div class="detail-item__content">
+            <div class="detail-item__label ">
+         
+
+  Sign up for text alerts
+
+      </div>
+                     <div class="detail-item__body ">
+                               <div class="field field-name-field-sidebar-text field-type-text-long field-label-hidden field-items">
+                <div>
+        <p>Text BOSCOVID to 888-777 to opt-in for&nbsp;alerts in English. <a href="https://www.boston.gov/node/11565951">We also have text alerts in 10 other languages</a>.</p>
+
+            </div>
+          </div>
+
+                     </div>
+         </div>
+</div>
+    </div>
+  
+
+          </div>
+
+    <div class="clearfix"></div>
+
+  </div>
+
+      <div class="department-components desktop-100">
+      
+            <div class="paragraphs-items paragraphs-items-field-components paragraphs-items-full paragraphs-items-field-components-full">
+                            <a class="subnav-anchor" name="covid-19-info" data-text="COVID-19 info"></a>
+                <div class="entity entity-paragraphs-item component-section paragraphs-item-transaction-grid b b--g b--fw" bos_context_type="Transaction Grid">
+  <div class="b-c">
+
+    <div class="sh cl">
+
+      
+
+      
+    <h2 class="sh-title">COVID-19 information</h2>
+
+
+                
+	    
+    </div>
+    <div class="g">
+                    <a href="https://www.boston.gov/news/information-face-coverings-covid-19" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="166217">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>person</title><path d="M84.69,63.55H62.21L46,75.82v41.84H100.8V76.29ZM97.8,114.66H49V77.31L63.22,66.55H83.64L97.8,77.74Z" fill="#0f1f2d"></path><polygon points="97.8 77.73 97.8 114.66 48.97 114.66 48.97 77.31 63.22 66.55 83.64 66.55 97.8 77.73" fill="#fff"></polygon><path d="M72.92,26.34A15.26,15.26,0,1,0,88.18,41.59,15.27,15.27,0,0,0,72.92,26.34Zm0,27.51A12.26,12.26,0,1,1,85.18,41.59,12.27,12.27,0,0,1,72.92,53.85Z" fill="#0f1f2d"></path><path d="M85.18,41.59A12.26,12.26,0,1,1,72.92,29.34,12.27,12.27,0,0,1,85.18,41.59Z" fill="#fff"></path></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Information on face coverings
+    </span>
+</a>
+
+
+
+      <a href="https://www.boston.gov/departments/public-health-commission/when-you-should-be-tested-covid-19" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="166010">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>emergency_medical_kit</title><rect x="21.73" y="47.94" width="100.53" height="65.48" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><line x1="22" y1="80.56" x2="122" y2="80.56" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line><circle cx="72" cy="80.56" r="14.83" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></circle><polyline points="53.5 48.06 53.5 33.56 90.5 33.56 90.5 48.06" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polyline><line x1="72" y1="89.59" x2="72" y2="71.54" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line><line x1="81.02" y1="80.56" x2="62.98" y2="80.56" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        When you should be tested
+    </span>
+</a>
+
+
+
+      <a href="https://www.boston.gov/news/covid-19-status-city-boston-departments" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="165945">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>city_hall</title><rect x="51.96" y="83.7" width="22.67" height="36.4" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="39.27" y="65.48" width="65.4" height="20.82" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="27.76" y="64.11" width="13.76" height="56.01" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="102.77" y="64.09" width="13.76" height="56.01" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="13.06" y="23.87" width="117.87" height="20.82" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="27.98" y="44.69" width="87.99" height="20.82" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect><rect x="21.11" y="30.23" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="34.5" y="30.23" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="47.86" y="30.23" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="61.24" y="30.23" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="74.63" y="30.23" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="101.37" y="30.23" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="88.02" y="30.23" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="114.76" y="30.23" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="34.5" y="50.35" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="47.86" y="50.35" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="61.24" y="50.35" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="74.63" y="50.35" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="88.02" y="50.35" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="101.37" y="50.35" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="61.24" y="71.84" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="74.63" y="71.84" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="74.58" y="71.84" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="87.96" y="71.84" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="47.91" y="71.84" width="8.1" height="8.1" fill="#0f1f2d"></rect><rect x="41.53" y="106.58" width="46.46" height="13.52" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></rect></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Status and hours of City departments
+    </span>
+</a>
+
+
+
+      <a href="https://www.boston.gov/news/transportation-department-covid-19-updates" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="165917">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>car</title><polygon points="99.48 56.05 92.46 41.77 67.54 41.77 67.54 56.05 99.48 56.05" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polygon><polygon points="30.54 56.04 37.3 41.77 62.22 41.77 62.22 56.04 30.54 56.04" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polygon><polygon points="21.09 60.95 34.06 36.28 95.38 36.28 109.45 61.85 21.09 60.95" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3" fill-rule="evenodd"></polygon><polygon points="99.48 56.05 92.46 41.77 67.54 41.77 67.54 56.05 99.48 56.05" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3" fill-rule="evenodd"></polygon><polygon points="30.54 56.04 37.3 41.77 62.22 41.77 62.22 56.04 30.54 56.04" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3" fill-rule="evenodd"></polygon><polygon points="8.25 60.56 125.26 60.56 135.75 71.56 135.75 92.66 8.25 92.66 8.25 60.56" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3" fill-rule="evenodd"></polygon><circle cx="38.52" cy="93.05" r="14.68" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></circle><circle cx="38.52" cy="93.05" r="8.26" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></circle><circle cx="99.27" cy="93.05" r="14.68" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></circle><circle cx="99.27" cy="93.05" r="8.26" fill="#fff" stroke="#0f1f2d" stroke-miterlimit="10" stroke-width="3"></circle><line x1="66.4" y1="62.68" x2="66.4" y2="91.01" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line><line x1="29.99" y1="68.05" x2="38.42" y2="68.05" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line><line x1="74.02" y1="68.05" x2="82.45" y2="68.05" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Transportation and parking updates
+    </span>
+</a>
+
+
+
+      <a href="https://www.boston.gov/departments/public-health-commission/coronavirus-guidance" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="166377">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>training</title><rect x="16.57" y="20.95" width="67.16" height="44.04" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></rect><polygon points="119.28 64.09 119.28 60.09 119.28 52.42 110.74 45.67 98.64 45.67 90.04 52.17 90.04 60.09 90.04 64.09 119.28 64.09" fill="#fff" stroke="#121f2c" stroke-miterlimit="10" stroke-width="0.98"></polygon><path d="M90.85,64.09V52.57l8.06-6.1h11.56l8,6.34V64.09Zm29.24,0V52L111,44.87H98.37l-9.13,6.9V64.09Z" fill="#111f2d" stroke="#121f2c" stroke-miterlimit="10" stroke-width="0.98"></path><circle cx="104.66" cy="32.44" r="7.76" fill="#fff" stroke="#121f2c" stroke-miterlimit="10" stroke-width="0.98"></circle><path d="M104.66,41a8.57,8.57,0,1,1,8.57-8.56A8.57,8.57,0,0,1,104.66,41Zm0-15.52a7,7,0,1,0,7,7A7,7,0,0,0,104.66,25.48Z" fill="#111f2d" stroke="#121f2c" stroke-miterlimit="10" stroke-width="0.98"></path><line x1="120.28" y1="73.4" x2="89.05" y2="73.4" fill="#fff" stroke="#121f2c" stroke-miterlimit="10" stroke-width="3"></line><polyline points="120.28 68.5 120.28 111.75 89.05 111.75 89.05 68.5" fill="#fff" stroke="#121f2c" stroke-miterlimit="10" stroke-width="3"></polyline><rect x="79.56" y="59.52" width="50.21" height="12.47" fill="#fff" stroke="#121f2c" stroke-miterlimit="10" stroke-width="3.33"></rect><polygon points="41.09 103.02 26.78 103.02 16.61 110.7 16.61 137.12 51.19 137.12 51.19 111 41.09 103.02" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polygon><circle cx="33.59" cy="87.37" r="9.18" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></circle><polygon points="75.83 103.02 61.51 103.02 51.34 110.7 51.34 137.12 85.92 137.12 85.92 111 75.83 103.02" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polygon><circle cx="68.33" cy="87.37" r="9.18" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></circle><polygon points="110.02 103.02 95.71 103.02 85.54 110.7 85.54 137.12 120.12 137.12 120.12 111 110.02 103.02" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polygon><circle cx="102.52" cy="87.37" r="9.18" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></circle><line x1="57.08" y1="38.12" x2="83.51" y2="57.72" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Guidance
+    </span>
+</a>
+
+
+
+      <a href="https://www.boston.gov/departments/public-health-commission/coronavirus-common-questions" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="166261">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>question</title><circle cx="70.79" cy="72" r="52.42" fill="#fff" stroke="#0d202e" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></circle><circle cx="70.79" cy="72" r="45.16" fill="#fff" stroke="#0d202e" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></circle><path d="M77.36,82.53H64.28V76.07a11.91,11.91,0,0,1,.91-5.29A23,23,0,0,1,69,66l5.85-6a6.78,6.78,0,0,0-.08-8.09,4.48,4.48,0,0,0-3.61-1.64,4.57,4.57,0,0,0-3.74,1.94,9.8,9.8,0,0,0-1.85,5.11H51.92q1-8.6,6.29-13.5a19.06,19.06,0,0,1,13.38-4.89q8,0,13.07,4.4t5,12.13a11.76,11.76,0,0,1-.86,5.12c-.58,1.12-1,1.92-1.21,2.4A11.84,11.84,0,0,1,86,65.17q-1.26,1.45-1.68,1.89-2.07,2.06-3.92,3.86a13.39,13.39,0,0,0-2.45,3,7.66,7.66,0,0,0-.61,3.48Z" fill="none" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"></path><path d="M65.6,102.88a7.68,7.68,0,1,1,5.37,2.2A7.31,7.31,0,0,1,65.6,102.88Z" fill="none" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"></path></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Common questions
+    </span>
+</a>
+
+
+
+      <a href="https://www.boston.gov/departments/public-health-commission/coronavirus-timeline" class="entity entity-paragraphs-item component-section paragraphs-item-transactions lwi g--3 g--3--sl m-t200 m-t500--m" bos_context_type="Transactions" target="_blank">
+    <span class="lwi-ic" bos-media-id="165948">
+        <article>
+                      <div width="100" height="100" typeof="foaf:Image">
+    <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144"><title>clock</title><circle cx="72" cy="72" r="50.5" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></circle><polyline points="98.21 42.3 72 77.07 72.23 105.39" fill="none" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></polyline><line x1="72.27" y1="21.8" x2="72.27" y2="28.36" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line><line x1="72.27" y1="115.25" x2="72.27" y2="121.8" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line><line x1="21.77" y1="72.3" x2="28.32" y2="72.3" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line><line x1="115.21" y1="72.3" x2="121.77" y2="72.3" fill="#fff" stroke="#0f1f2d" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"></line></svg>
+  </div>
+
+
+      
+  </article>
+
+    </span>
+    <span class="lwi-t">
+        Timeline
+    </span>
+</a>
+
+
+
+  
+
+          </div>
+  </div>
+</div>
+
+                            <a class="subnav-anchor" name="get-help" data-text="Get help"></a>
+                <div class="entity entity-paragraphs-item component-section paragraphs-item-group-of-links-mini-grid" bos_context_type="Group Of Links Mini Grid">
+
+  <div class="content">
+
+    <div class="sh cl">
+
+      
+
+      
+    <h2 class="sh-title">Get help</h2>
+
+
+              	<span class="field field-name-field-short-title field-type-text field-type-string component-short-title">
+		Get help
+	</span>
+
+      
+      
+    </div>
+
+    <div class="links-grid-field-grid-links links-grid-field-mini-grid-links mobile-100 clearfix">
+      
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/421906">
+  <div class="link-item">
+    <a href="https://www.boston.gov/news/food-resources-during-covid-19" title="Go to Food resources in Boston" target="_blank">Food resources in Boston</a>
+  </div>
+  Food resources in Boston
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/421911">
+  <div class="link-item">
+    <a href="https://www.boston.gov/news/covid-19-housing-response" title="Go to Housing and homeless resources" target="_blank">Housing and homeless resources</a>
+  </div>
+  Housing and homeless resources
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/421916">
+  <div class="link-item">
+    <a href="https://www.boston.gov/news/covid-19-resource-guide-bostons-immigrants" title="Go to Resource guide for immigrants" target="_blank">Resource guide for immigrants</a>
+  </div>
+  Resource guide for immigrants
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/421921">
+  <div class="link-item">
+    <a href="https://drive.google.com/file/d/1qdEQbH9WVCA6Eofp8xFJIPZ9LLVhaWIY/view" title="Go to Resources for residents with disabilities" target="_blank">Resources for residents with disabilities</a>
+  </div>
+  Resources for residents with disabilities
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/422826">
+  <div class="link-item">
+    <a href="https://www.boston.gov/news/city-boston-expands-covid-19-text-service-include-11-languages" title="Go to Sign up for text alerts in 11 languages" target="_blank">Sign up for text alerts in 11 languages</a>
+  </div>
+  Sign up for text alerts in 11 languages
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/422831">
+  <div class="link-item">
+    <a href="https://www.boston.gov/departments/public-health-commission/map-covid-19-testing-sites" title="Go to Find a free COVID-19 testing site" target="_blank">Find a free COVID-19 testing site</a>
+  </div>
+  Find a free COVID-19 testing site
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/421926">
+  <div class="link-item">
+    <a href="https://www.boston.gov/news/transportation-department-covid-19-updates#transit-help-for-medical-staff" title="Go to Transportation help for hospital staff" target="_blank">Transportation help for hospital staff</a>
+  </div>
+  Transportation help for hospital staff
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/421931">
+  <div class="link-item">
+    <a href="https://www.boston.gov/news/internet-connectivity-and-technology-supports-during-covid-19-response" title="Go to Internet and technology support for residents" target="_blank">Internet and technology support for residents</a>
+  </div>
+  Internet and technology support for residents
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/421936">
+  <div class="link-item">
+    <a href="https://www.buoyhealth.com/mass" title="Go to Buoy Health free online COVID-19 screenings" target="_blank">Buoy Health free online COVID-19 screenings</a>
+  </div>
+  Buoy Health free online COVID-19 screenings
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/421941">
+  <div class="link-item">
+    <a href="https://www.nesterlygoodneighbors.com/" title="Go to Good Neighbor free deliveries and check-ins " target="_blank">Good Neighbor free deliveries and check-ins </a>
+  </div>
+  Good Neighbor free deliveries and check-ins 
+</div>
+
+
+    </div>
+  </div>
+
+    </div>
+
+  </div>
+</div>
+
+                            <a class="subnav-anchor" name="relief-funds" data-text="Relief funds"></a>
+                <div class="entity entity-paragraphs-item component-section paragraphs-item-grid-of-cards b--b b b--fw" bos_context_type="Grid Of Cards">
+
+  <div class="b-c">
+
+    <div class="sh sh--w">
+
+      
+
+      
+    <h2 class="sh-title">Relief funds</h2>
+
+
+      
+
+              <div class="sh-contact">
+          
+        </div>
+      
+    </div>
+
+    <div class="g">
+                          
+
+<a href="https://www.boston.gov/departments/treasury/boston-resiliency-fund" class="entity entity-paragraphs-item component-section paragraphs-item-card cd g--4 g--4--sl m-t500" bos_context_type="Card">
+
+  <div class="cd-ic cd-ic-415386"></div>
+
+  <div class="cd-c">
+
+    <div class="cd-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>Boston Resiliency Fund</p>
+
+            </div>
+          </div>
+</div>
+
+          <div class="cd-st t--upper t--subtitle"></div>
+    
+    <div class="cd-d">    <div class="field field-name-field-short-description field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>We're helping coordinate the City's fundraising efforts to support City of Boston residents most affected by the coronavirus (COVID-19).</p>
+
+            </div>
+          </div>
+</div>
+
+  </div>
+
+</a>
+
+              
+
+<a href="https://www.boston.gov/departments/neighborhood-development/office-housing-stability/rental-relief-fund" class="entity entity-paragraphs-item component-section paragraphs-item-card cd g--4 g--4--sl m-t500" bos_context_type="Card">
+
+  <div class="cd-ic cd-ic-415481"></div>
+
+  <div class="cd-c">
+
+    <div class="cd-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>Rental Relief Fund</p>
+
+            </div>
+          </div>
+</div>
+
+          <div class="cd-st t--upper t--subtitle"></div>
+    
+    <div class="cd-d">    <div class="field field-name-field-short-description field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>We're dedicating $3 million in City funds to help Boston residents at risk of losing their rental housing due to the COVID-19 pandemic.</p>
+
+            </div>
+          </div>
+</div>
+
+  </div>
+
+</a>
+
+              
+
+<a href="https://www.boston.gov/departments/economic-development/small-business-relief-fund" class="entity entity-paragraphs-item component-section paragraphs-item-card cd g--4 g--4--sl m-t500" bos_context_type="Card">
+
+  <div class="cd-ic cd-ic-415491"></div>
+
+  <div class="cd-c">
+
+    <div class="cd-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>Small Business Relief Fund</p>
+
+            </div>
+          </div>
+</div>
+
+          <div class="cd-st t--upper t--subtitle"></div>
+    
+    <div class="cd-d">    <div class="field field-name-field-short-description field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>We established the Small Business Financial Relief Fund to help businesses most impacted by COVID-19. We want to provide immediate help and guidance.</p>
+
+            </div>
+          </div>
+</div>
+
+  </div>
+
+</a>
+
+              
+
+<a href="https://www.boston.gov/news/boston-establishes-artist-relief-fund-response-coronavirus" class="entity entity-paragraphs-item component-section paragraphs-item-card cd g--4 g--4--sl m-t500" bos_context_type="Card">
+
+  <div class="cd-ic cd-ic-415396"></div>
+
+  <div class="cd-c">
+
+    <div class="cd-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>Artist Relief Fund</p>
+
+            </div>
+          </div>
+</div>
+
+          <div class="cd-st t--upper t--subtitle"></div>
+    
+    <div class="cd-d">    <div class="field field-name-field-short-description field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>The fund will award grants of $500 and $1,000 to individual artists who live in Boston whose creative practices and incomes are being adversely impacted by COVID-19.</p>
+
+            </div>
+          </div>
+</div>
+
+  </div>
+
+</a>
+
+      
+          </div>
+
+  </div>
+
+</div>
+
+                            <a class="subnav-anchor" name="get-involved" data-text="Get involved"></a>
+                
+
+    
+<div class="entity entity-paragraphs-item component-section paragraphs-item-group-of-links-grid" bos_context_type="Group Of Links Grid">
+  <div class="content">
+    <div class="sh cl">
+      
+      
+    <h2 class="sh-title">Get involved</h2>
+
+      
+      
+    </div>
+    <div class="links-grid-left-rail mobile-100 tablet-100 desktop-25-left">
+              <div class="links-grid-field-subheader">
+                      We have information on how you can support COVID-19 efforts in Boston.
+      
+        </div>
+                  
+    </div>
+    <div class="links-grid-field-grid-links mobile-100 tablet desktop-75-right">
+                    <div class="entity entity-paragraphs-item component-section paragraphs-item-grid-links desktop-3-col clearfix tablet-2-col field-grid-links" bos_context_type="Grid Links">
+    <div class="content">
+              <div class="grid-link">
+                        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/421841">
+  <div class="link-item">
+    <a href="https://www.nesterlygoodneighbors.com/" title="Go to Become a Good Neighbor" target="_blank">Become a Good Neighbor</a>
+  </div>
+  Become a Good Neighbor
+</div>
+
+
+      
+        </div>
+                    <div class="grid-description">
+          <div class="field field-name-field-short-description field-type-text field-label-hidden">
+                        <p>Volunteers offer free deliveries and check-ins for those at-risk.</p>
+
+      
+          </div>
+        </div>
+                </div>
+  </div>
+
+                <div class="entity entity-paragraphs-item component-section paragraphs-item-grid-links desktop-3-col clearfix tablet-2-col field-grid-links" bos_context_type="Grid Links">
+    <div class="content">
+              <div class="grid-link">
+                        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/421851">
+  <div class="link-item">
+    <a href="https://www.boston.gov/departments/veterans-services/veterans-services-penpals-and-buddies" title="Go to Veterans Services penpals and buddies program" target="_blank">Veterans Services penpals and buddies program</a>
+  </div>
+  Veterans Services penpals and buddies program
+</div>
+
+
+      
+        </div>
+                    <div class="grid-description">
+          <div class="field field-name-field-short-description field-type-text field-label-hidden">
+                        <p>We connect volunteer penpals and buddies with local veterans.</p>
+
+      
+          </div>
+        </div>
+                </div>
+  </div>
+
+                <div class="entity entity-paragraphs-item component-section paragraphs-item-grid-links desktop-3-col clearfix tablet-2-col field-grid-links" bos_context_type="Grid Links">
+    <div class="content">
+              <div class="grid-link">
+                        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/421861">
+  <div class="link-item">
+    <a href="https://docs.google.com/forms/d/1tdQSR1nWprrkhbqxawKg9FMt1nFK-hts20ZaCd_FoYE/viewform?ts=5e7d0b66&amp;edit_requested=true" title="Go to Volunteer with the City of Boston" target="_blank">Volunteer with the City of Boston</a>
+  </div>
+  Volunteer with the City of Boston
+</div>
+
+
+      
+        </div>
+                    <div class="grid-description">
+          <div class="field field-name-field-short-description field-type-text field-label-hidden">
+                        <p>We're connecting volunteers with future opportunities.</p>
+
+      
+          </div>
+        </div>
+                </div>
+  </div>
+
+                <div class="entity entity-paragraphs-item component-section paragraphs-item-grid-links desktop-3-col clearfix tablet-2-col field-grid-links" bos_context_type="Grid Links">
+    <div class="content">
+              <div class="grid-link">
+                        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/421871">
+  <div class="link-item">
+    <a href="https://bostonopendata.knack.com/covid-19-donation-intake-form" title="Go to Donate supplies to first responders" target="_blank">Donate supplies to first responders</a>
+  </div>
+  Donate supplies to first responders
+</div>
+
+
+      
+        </div>
+                    <div class="grid-description">
+          <div class="field field-name-field-short-description field-type-text field-label-hidden">
+                        <p>Help support our first responders and public health partners.</p>
+
+      
+          </div>
+        </div>
+                </div>
+  </div>
+
+                <div class="entity entity-paragraphs-item component-section paragraphs-item-grid-links desktop-3-col clearfix tablet-2-col field-grid-links" bos_context_type="Grid Links">
+    <div class="content">
+              <div class="grid-link">
+                        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/421961">
+  <div class="link-item">
+    <a href="https://www.redcrossblood.org/" title="Go to Make an appointment to donate blood to Red Cross" target="_blank">Make an appointment to donate blood to Red Cross</a>
+  </div>
+  Make an appointment to donate blood to Red Cross
+</div>
+
+
+      
+        </div>
+                    <div class="grid-description">
+          <div class="field field-name-field-short-description field-type-text field-label-hidden">
+                        <p>Many blood drives were canceled and there is a critical shortage.</p>
+
+      
+          </div>
+        </div>
+                </div>
+  </div>
+
+      
+    </div>
+  </div>
+</div>
+
+                            <a class="subnav-anchor" name="maps-and-dashboards" data-text="Maps and dashboards"></a>
+                <div class="entity entity-paragraphs-item component-section paragraphs-item-grid-of-cards b--w b b--fw" bos_context_type="Grid Of Cards">
+
+  <div class="b-c">
+
+    <div class="sh">
+
+      
+
+      
+    <h2 class="sh-title">Maps and dashboards</h2>
+
+
+      
+
+              <div class="sh-contact">
+          
+        </div>
+      
+    </div>
+
+    <div class="g">
+                          
+
+<a href="https://www.boston.gov/departments/food-access/map-covid19-food-resources" class="entity entity-paragraphs-item component-section paragraphs-item-card cd g--4 g--4--sl m-t500" bos_context_type="Card">
+
+  <div class="cd-ic cd-ic-415841"></div>
+
+  <div class="cd-c">
+
+    <div class="cd-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>Food resources map</p>
+
+            </div>
+          </div>
+</div>
+
+          <div class="cd-st t--upper t--subtitle"></div>
+    
+    <div class="cd-d">    <div class="field field-name-field-short-description field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>Our map features breakfast and lunch meal sites for Boston students, as well as food pantry locations.</p>
+
+            </div>
+          </div>
+</div>
+
+  </div>
+
+</a>
+
+              
+
+<a href="https://www.boston.gov/news/discounted-garages-hospital-staff-boston" class="entity entity-paragraphs-item component-section paragraphs-item-card cd g--4 g--4--sl m-t500" bos_context_type="Card">
+
+  <div class="cd-ic cd-ic-415851"></div>
+
+  <div class="cd-c">
+
+    <div class="cd-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>Discounted garages for hospital staff in Boston</p>
+
+            </div>
+          </div>
+</div>
+
+          <div class="cd-st t--upper t--subtitle"></div>
+    
+    <div class="cd-d">    <div class="field field-name-field-short-description field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>Some garages and lots in the City have been offering discounted parking for medical professionals.</p>
+
+            </div>
+          </div>
+</div>
+
+  </div>
+
+</a>
+
+              
+
+<a href="https://www.boston.gov/departments/womens-advancement/emergency-childcare-programs" class="entity entity-paragraphs-item component-section paragraphs-item-card cd g--4 g--4--sl m-t500" bos_context_type="Card">
+
+  <div class="cd-ic cd-ic-415861"></div>
+
+  <div class="cd-c">
+
+    <div class="cd-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>Emergency childcare programs</p>
+
+            </div>
+          </div>
+</div>
+
+          <div class="cd-st t--upper t--subtitle"></div>
+    
+    <div class="cd-d">    <div class="field field-name-field-short-description field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>Emergency programs are being made available to emergency workers on a limited basis who have no other option for childcare.</p>
+
+            </div>
+          </div>
+</div>
+
+  </div>
+
+</a>
+
+              
+
+<a href="https://www.boston.gov/departments/public-health-commission/map-covid-19-testing-sites" class="entity entity-paragraphs-item component-section paragraphs-item-card cd g--4 g--4--sl m-t500" bos_context_type="Card">
+
+  <div class="cd-ic cd-ic-422126"></div>
+
+  <div class="cd-c">
+
+    <div class="cd-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>COVID-19 testing sites</p>
+
+            </div>
+          </div>
+</div>
+
+          <div class="cd-st t--upper t--subtitle"></div>
+    
+    <div class="cd-d">    <div class="field field-name-field-short-description field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>The City of Boston is partnering with community health centers to increase access to testing,</p>
+
+            </div>
+          </div>
+</div>
+
+  </div>
+
+</a>
+
+              
+
+<a href="https://dashboard.cityofboston.gov/t/Guest_Access_Enabled/views/COVID-19/Dashboard1?:showAppBanner=false&amp;:display_count=n&amp;:showVizHome=n&amp;:origin=viz_share_link&amp;:isGuestRedirectFromVizportal=y&amp;:embed=y" class="entity entity-paragraphs-item component-section paragraphs-item-card cd g--4 g--4--sl m-t500" bos_context_type="Card">
+
+  <div class="cd-ic cd-ic-421891"></div>
+
+  <div class="cd-c">
+
+    <div class="cd-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>COVID-19 cases in Boston</p>
+
+            </div>
+          </div>
+</div>
+
+          <div class="cd-st t--upper t--subtitle"></div>
+    
+    <div class="cd-d">    <div class="field field-name-field-short-description field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>View a dashboard of City of Boston data.</p>
+
+            </div>
+          </div>
+</div>
+
+  </div>
+
+</a>
+
+              
+
+<a href="http://boston.maps.arcgis.com/apps/opsdashboard/index.html#/a2f67ae8147948919ea2f99dd09d0955" class="entity entity-paragraphs-item component-section paragraphs-item-card cd g--4 g--4--sl m-t500" bos_context_type="Card">
+
+  <div class="cd-ic cd-ic-421901"></div>
+
+  <div class="cd-c">
+
+    <div class="cd-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>COVID-19 cases in Mass.</p>
+
+            </div>
+          </div>
+</div>
+
+          <div class="cd-st t--upper t--subtitle"></div>
+    
+    <div class="cd-d">    <div class="field field-name-field-short-description field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        <p>View a dashboard of statewide data.</p>
+
+            </div>
+          </div>
+</div>
+
+  </div>
+
+</a>
+
+      
+          </div>
+
+  </div>
+
+</div>
+
+                            <a class="subnav-anchor" name="multilingual-help" data-text="Multilingual help"></a>
+                <div class="entity entity-paragraphs-item component-section paragraphs-item-group-of-links-mini-grid" bos_context_type="Group Of Links Mini Grid">
+
+  <div class="content">
+
+    <div class="sh cl">
+
+      
+
+      
+    <h2 class="sh-title">Multilingual help</h2>
+
+
+              	<span class="field field-name-field-short-title field-type-text field-type-string component-short-title">
+		Multilingual help
+	</span>
+
+      
+      
+    </div>
+
+    <div class="links-grid-field-grid-links links-grid-field-mini-grid-links mobile-100 clearfix">
+      
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/412006">
+  <div class="link-item">
+    <a href="http://www.boston.gov/covid-19-ar" title="Go to العربية (Arabic)" target="_blank">العربية (Arabic)</a>
+  </div>
+  العربية (Arabic)
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/412011">
+  <div class="link-item">
+    <a href="https://www.boston.gov/covid-19-cv" title="Go to kriolu (Cabo Verdean Creole)" target="_blank">kriolu (Cabo Verdean Creole)</a>
+  </div>
+  kriolu (Cabo Verdean Creole)
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/412016">
+  <div class="link-item">
+    <a href="https://www.boston.gov/covid-19-zh" title="Go to 中文 (Chinese)" target="_blank">中文 (Chinese)</a>
+  </div>
+  中文 (Chinese)
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/412021">
+  <div class="link-item">
+    <a href="https://www.boston.gov/covid-19-fr" title="Go to Français (French)" target="_blank">Français (French)</a>
+  </div>
+  Français (French)
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/412026">
+  <div class="link-item">
+    <a href="https://www.boston.gov/covid-19-hc" title="Go to Kreyòl ayisyen (Haitian Creole)" target="_blank">Kreyòl ayisyen (Haitian Creole)</a>
+  </div>
+  Kreyòl ayisyen (Haitian Creole)
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/412031">
+  <div class="link-item">
+    <a href="https://www.boston.gov/covid-19-pt" title="Go to Português (Portuguese)" target="_blank">Português (Portuguese)</a>
+  </div>
+  Português (Portuguese)
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/412036">
+  <div class="link-item">
+    <a href="https://www.boston.gov/covid-19-ru" title="Go to Русский (Russian)" target="_blank">Русский (Russian)</a>
+  </div>
+  Русский (Russian)
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/412041">
+  <div class="link-item">
+    <a href="https://www.boston.gov/covid-19-so" title="Go to Af-Soomali (Somali)" target="_blank">Af-Soomali (Somali)</a>
+  </div>
+  Af-Soomali (Somali)
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/412046">
+  <div class="link-item">
+    <a href="https://www.boston.gov/covid-19-es" title="Go to Español (Spanish)" target="_blank">Español (Spanish)</a>
+  </div>
+  Español (Spanish)
+</div>
+
+
+    </div>
+  </div>
+  <div class="field-grid-links clearfix desktop-3-col clearfix tablet-2-col">
+    <div class="grid-link">
+        
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper separated-link" data-quickedit-entity-id="paragraph/412051">
+  <div class="link-item">
+    <a href="https://www.boston.gov/covid-19-vi" title="Go to Tiếng Việt (Vietnamese)" target="_blank">Tiếng Việt (Vietnamese)</a>
+  </div>
+  Tiếng Việt (Vietnamese)
+</div>
+
+
+    </div>
+  </div>
+
+    </div>
+
+  </div>
+</div>
+
+                            <a class="subnav-anchor" name="local-support" data-text="Local support"></a>
+                
+
+  
+<div class="entity entity-paragraphs-item component-section paragraphs-item-group-of-links-list" bos_context_type="Group Of Links List">
+
+  <div class="content container">
+
+    <div class="sh cl">
+
+      
+
+      
+    <h2 class="sh-title">Local support</h2>
+
+
+              	<span class="field field-name-field-short-title field-type-text field-type-string component-short-title">
+		Local support
+	</span>
+
+      
+      
+    </div>
+
+    <div class="links-grid-left-rail mobile-100">
+
+      <div class="links-grid-field-subheader">
+        
+      </div>
+
+      <div class="links-grid-field-description">
+        
+      </div>
+
+      
+    </div>
+
+    <div class="links-grid-field-list-links mobile-100 desktop-100">
+                  
+<div class="entity entity-paragraphs-item component-section paragraphs-item-gol-list-links clearfix desktop-1-col" bos_context_type="Gol List Links">
+  <div class="content">
+    <div class="list-link tablet-33-left">
+      
+    
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper" data-quickedit-entity-id="paragraph/421986">
+  <div class="link-item ribbon">
+    <a href="https://www.boston.gov/departments/small-business-development/supporting-bostons-open-businesses" title="Go to Support Boston&#39;s open businesses" target="_blank">Support Boston's open businesses</a>
+  </div>
+  Support Boston's open businesses
+      <div class="link-icon-ribbon"></div>
+  </div>
+
+
+
+    </div>
+    <div class="list-description tablet-66-right">
+      
+  <p>You can find essential businesses that remain open during the COVID-19 crisis, or add a business to our list.</p>
+
+
+    </div>
+  </div>
+</div>
+
+              
+<div class="entity entity-paragraphs-item component-section paragraphs-item-gol-list-links clearfix desktop-1-col" bos_context_type="Gol List Links">
+  <div class="content">
+    <div class="list-link tablet-33-left">
+      
+    
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper" data-quickedit-entity-id="paragraph/421996">
+  <div class="link-item ribbon">
+    <a href="https://www.boston.gov/departments/small-business-development/support-bostons-restaurants" title="Go to Support for Boston restaurants" target="_blank">Support for Boston restaurants</a>
+  </div>
+  Support for Boston restaurants
+      <div class="link-icon-ribbon"></div>
+  </div>
+
+
+
+    </div>
+    <div class="list-description tablet-66-right">
+      
+  <p>Find local restaurants that remain open for takeout and delivery service. You can also add restaurants to our list.</p>
+
+
+    </div>
+  </div>
+</div>
+
+              
+<div class="entity entity-paragraphs-item component-section paragraphs-item-gol-list-links clearfix desktop-1-col" bos_context_type="Gol List Links">
+  <div class="content">
+    <div class="list-link tablet-33-left">
+      
+    
+<div class="external-link field field-name-field-external-link field-type-link link-wrapper" data-quickedit-entity-id="paragraph/422006">
+  <div class="link-item ribbon">
+    <a href="https://www.boston.gov/departments/arts-and-culture/boston-virtual-arts-and-cultural-events" title="Go to Support for virtual arts and culture events" target="_blank">Support for virtual arts and culture events</a>
+  </div>
+  Support for virtual arts and culture events
+      <div class="link-icon-ribbon"></div>
+  </div>
+
+
+
+    </div>
+    <div class="list-description tablet-66-right">
+      
+  <p>You can find virtual arts and cultural events and programs organized by groups in Greater Boston, or add your own event to...</p>
+
+
+    </div>
+  </div>
+</div>
+
+      
+    </div>
+
+  </div>
+
+</div>
+
+                            <a class="subnav-anchor" name="latest-press-conference" data-text="Latest press conference"></a>
+                <div class="b b--fw contextual-region" bos_context_type="Video">
+
+  
+  
+
+  <div class="entity entity-paragraphs-item component-section paragraphs-item-video vid" bos_context_type="Video" id="vid" data-vid-id="pH7o-zrnBqw" data-vid-channel="false">
+
+          <div class="vid ph-p ph-p-1"></div>
+    
+    <div class="vid-c">
+      <div class="vid-ci">
+        <div class="b-c">
+
+          <div class="vid-t">
+
+            
+    <span>Watch: Latest Mayor Walsh press conference</span>
+
+
+          </div>
+
+          
+          <div class="vid-ic m-t300">
+            <button class="vid-cta">
+              <img src="./CoronavirusDiseaseinBoston.gov_files/play.svg" alt="Play Video" height="97" width="97" class="vid-cta-i">
+            </button>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+</div>
+
+                            <a></a>
+                
+<div class="entity entity-paragraphs-item paragraphs-item-text component-section entity entity-paragraphs-item component-section" bos_context_type="Text" about="" typeof="">
+  <div class="content">
+      	  <div class="sh">
+        
+    <h2 class="sh-title">About our response</h2>
+
+                  
+              </div>
+              <div class="paragraphs-items paragraphs-items-field-text-blocks paragraphs-items-field-text-blocks-full paragraphs-items-full">
+                     
+<div class="entity entity-paragraphs-item paragraphs-item-text-two-column component-section col_half entity entity-paragraphs-item component-section" bos_context_type="Text Two Column">
+
+  <div class="content">
+        <div class="field field-label-hidden field-name-field-left-column field-type-text-long field-items">
+            <address>City of Boston response</address>
+<p><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span>Since January, the <a href="https://bphc.org/whatwedo/infectious-diseases/Infectious-Diseases-A-to-Z/covid-19/Pages/default.aspx">Boston Public Health Commission</a> and Boston EMS have taken extensive steps to prepare for a potential outbreak of COVID-19.&nbsp;</span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span>BPHC and Boston EMS are trained to respond to infectious diseases. In the past, we have successfully stood up heightened awareness, monitoring and response approaches for SARS, MERS, and H1N1 flu. We will do the same for COVID-19.</span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></p>
+<p><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span>BPHC is engaging in daily communications with the CDC, the Massachusetts Department of Public Health (MDPH), City of Boston departments and other community partners to make sure we have the latest information on guidance, best practices and recommendations. BPHC will provide updated information on this website and on our social media channels as it becomes available.</span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></p>
+<p><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span>We are confident the City of B</span></span></span></span></span></span></span></span></span></span></span></span></span></span></span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span>oston will be ready for a safe and effective respons</span></span></span></span></span></span></span></span></span></span></span></span></span></span></span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span>e as the situation develops.</span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></p>
+
+          </div>
+    <div class="field field-label-hidden field-name-field-right-column field-type-text-long field-items">
+            <address>State and federal response</address>
+<p><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span>T</span></span></span></span></span></span></span></span></span></span></span></span></span></span></span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span>he state of Massachusetts is updating information about COVID-19 cases and residents subject to quarantine in Massachusetts.&nbsp;</span></span></span></span></span></span></span></span></span></span></span></span></span></span></span><a href="https://www.mass.gov/info-details/covid-19-quarantine-and-monitoring">Visit the MDPH webpage on COVID-19 quarantine and monitoring in the Commonwealth.</a>&nbsp;</span></span></span></span></span></span></span></span></span></span></span></span></span></span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span>The CDC is tracking confirmed cases across the United States. For the latest on case counts,&nbsp;</span></span></span></span></span></span></span></span></span></span></span></span></span></span></span><a href="https://www.cdc.gov/coronavirus/2019-nCoV/index.html">visit the CDC's website on COVID-19</a><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span>.&nbsp;</span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></p>
+<hr><address>City of boston Healthcare providers</address>
+<p>Healthcare providers in Boston should immediately notify BPHC&nbsp;at&nbsp;<a href="tel:617-534-5611">617-534-5611</a> if they suspect a patient is infected with&nbsp;COVID-19. Providers outside of Boston should contact MDPH at <a href="tel:617-983-6800">617-983-6800</a>. <a href="https://www.cdc.gov/coronavirus/2019-ncov/hcp/clinical-criteria.html?CDC_AA_refVal=https://www.cdc.gov/coronavirus/2019-ncov/clinical-criteria.html">CDC has created criteria to guide evaluation of patients</a> suspected to have&nbsp;COVID-19.</p>
+
+          </div>
+
+  </div>
+
+</div>
+
+      
+      </div>
+      </div>
+</div>
+
+                            <a class="subnav-anchor" name="list-of-resources" data-text="List of resources"></a>
+                
+<div class="entity entity-paragraphs-item component-section paragraphs-item-drawers" bos_context_type="Drawers">
+  <div class="content">
+    <div class="sh cl">
+      
+      
+    <h2 class="sh-title">List of resources</h2>
+
+              	<span class="field field-name-field-short-title field-type-text field-type-string component-short-title">
+		List of resources
+	</span>
+
+            
+    </div>
+    <div class="section-drawers">
+                  <div class="entity entity-paragraphs-item component-section paragraphs-item-drawer dr contextual-region" bos_context_type="Drawer">
+
+  <input type="checkbox" id="dr" class="dr-tr a11y--h">
+
+  <label for="dr" class="dr-h">
+
+	  <div class="dr-ic">
+	    <svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 8.5 18 25">
+		    <path class="dr-i" d="M16 21L.5 33.2c-.6.5-1.5.4-2.2-.2-.5-.6-.4-1.6.2-2l12.6-10-12.6-10c-.6-.5-.7-1.5-.2-2s1.5-.7 2.2-.2L16 21z"></path>
+	    </svg>
+    </div>
+
+	  <div class="dr-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        Local
+            </div>
+          </div>
+</div>
+
+	    </label>
+
+	<div class="dr-c">
+                <div class="entity entity-paragraphs-item paragraphs-item-text-three-column component-section entity entity-paragraphs-item component-section" bos_context_type="Text Three Column" about="" typeof="">
+  <div class="content">
+        <div class="field field-label-hidden field-name-field-left-column field-type-text-long field-items">
+            <ul><li><a href="https://bphc.org/whatwedo/infectious-diseases/Infectious-Diseases-A-to-Z/covid-19/Pages/default.aspx">Boston Public Health Commission Coronavirus (COVID-19) updates</a></li>
+<li><a href="https://www.bphc.org/whatwedo/infectious-diseases/Infectious-Diseases-A-to-Z/Documents/face%20covering.pdf">Boston Public Health Commission face coverings information (pdf)</a></li>
+<li><a href="https://bphc.org/whatwedo/infectious-diseases/Infectious-Diseases-A-to-Z/Documents/FAQ%20for%20COVID19.pdf">Boston Public Health Commission common questions (pdf)</a></li>
+<li><a href="https://www.bphc.org/whatwedo/infectious-diseases/Infectious-Diseases-A-to-Z/Documents/Cleaning%20and%20Disinfecting%20for%20COVID%2019.pdf">Boston Public Health Commission cleaning tips (pdf)</a></li>
+<li><a href="https://www.bphc.org/whatwedo/infectious-diseases/Infectious-Diseases-A-to-Z/Documents/Fact%20Sheet%20Languages/2019%20novel%20coronavirus/English.pdf">Boston Public Health Commission fact sheet (pdf)</a></li>
+<li><a href="https://bphc.org/whatwedo/infectious-diseases/Infectious-Diseases-A-to-Z/Documents/Coping%20Stress%20due%20to%20COVID19.pdf">Boston Public Health Commission tips on coping with stress (pdf)</a></li>
+<li><a href="https://www.boston.gov/sites/default/files/file/2020/03/Guidance%20for%20PPE%20Front%20Line%203-23-2020.pdf">Boston Public Health Commission&nbsp;COVID-19 PPE for frontline staff (pdf)</a></li>
+<li><a href="https://www.boston.gov/sites/default/files/file/2020/03/COVID-19%2011x17%20poster_English.pdf">Boston Public Health Commission COVID-19 poster</a></li>
+<li><a href="http://www.massleague.org/findahealthcenter/index.php">Find a health center near you</a></li>
+<li><a href="https://www.boston.gov/node/11564376">Inspectional Services tips on preventing the spread of coronavirus in food service establishments</a></li>
+</ul>
+          </div>
+    <div class="field field-label-hidden field-name-field-middle-column field-type-text-long field-items">
+            <ul><li><a href="https://www.boston.gov/sites/default/files/file/2020/03/walsh-letter-landlords.pdf">Mayor Walsh letter to landlords, realtors, and rental brokers</a></li>
+<li><a href="https://www.boston.gov/node/11564651">Mayor Walsh letter to the arts community</a></li>
+<li><a href="https://www.boston.gov/node/11564921">Temporary parking enforcement changes</a></li>
+<li><a href="https://www.boston.gov/node/11564536">Temporary guidance on City construction</a></li>
+<li><a href="https://www.boston.gov/news/boston-parks-and-recreation-interim-information-operations-and-events">Boston Parks information</a></li>
+<li><a href="https://www.boston.gov/node/11564126">Economic Development guidance</a></li>
+<li><a href="https://www.boston.gov/node/11564396">Transportation Department updates</a></li>
+<li><a href="https://www.boston.gov/node/11564901">Inspectional Services updates</a></li>
+<li><a href="https://www.boston.gov/node/11564526">Message from Disabilities Commissioner</a></li>
+<li><a href="https://www.boston.gov/node/11564531">Internet connectivity supports</a></li>
+<li><a href="https://www.boston.gov/node/11566046">Licensing Board advisories</a></li>
+<li><a href="https://www.boston.gov/node/81">Veterans Services update</a></li>
+</ul>
+          </div>
+    <div class="field field-label-hidden field-name-field-right-column field-type-text-long field-items">
+            <ul><li><a href="https://www.boston.gov/node/11564701">Guide for Boston's immigrants</a></li>
+<li><a href="https://www.boston.gov/node/11564806">Free Bluebikes offered to hospital staff</a></li>
+<li><a href="https://docs.google.com/document/d/1ux3uC16HyeLlPEPutqGpQEabxkwItqFqUOUzA-sMxyc/edit#heading=h.lebax96k1v8t">Resources for those experiencing homelessness</a></li>
+<li><a href="https://www.boston.gov/node/11565071">Food resources in Boston</a></li>
+<li><a href="https://www.boston.gov/node/11565156">Rental Relief Fund</a></li>
+<li><a href="https://www.boston.gov/node/11565141">Small Business Relief Fund</a></li>
+<li><a href="https://www.boston.gov/node/11563826">City of Boston Artist Relief Fund</a></li>
+<li><a href="https://www.boston.gov/node/11565226">Resources for youth virtual learning</a></li>
+<li><a href="https://www.boston.gov/node/11565276">Veterans Services penpals program</a></li>
+<li><a href="https://www.boston.gov/node/11564761">Support for open businesses</a></li>
+<li><a href="https://www.boston.gov/node/11564591">Support for local restaurants</a></li>
+<li><a href="https://www.boston.gov/node/11565711">Support for local arts events</a></li>
+</ul>
+          </div>
+
+  </div>
+</div>
+
+      
+  </div>
+</div>
+
+              <div class="entity entity-paragraphs-item component-section paragraphs-item-drawer dr contextual-region" bos_context_type="Drawer">
+
+  <input type="checkbox" id="dr--2" class="dr-tr a11y--h">
+
+  <label for="dr--2" class="dr-h">
+
+	  <div class="dr-ic">
+	    <svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 8.5 18 25">
+		    <path class="dr-i" d="M16 21L.5 33.2c-.6.5-1.5.4-2.2-.2-.5-.6-.4-1.6.2-2l12.6-10-12.6-10c-.6-.5-.7-1.5-.2-2s1.5-.7 2.2-.2L16 21z"></path>
+	    </svg>
+    </div>
+
+	  <div class="dr-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        Federal
+            </div>
+          </div>
+</div>
+
+	    </label>
+
+	<div class="dr-c">
+                
+<div class="entity entity-paragraphs-item paragraphs-item-text-two-column component-section col_half entity entity-paragraphs-item component-section" bos_context_type="Text Two Column">
+
+  <div class="content">
+        <div class="field field-label-hidden field-name-field-left-column field-type-text-long field-items">
+            <ul><li><a href="https://www.cdc.gov/coronavirus/2019-ncov/index.html">Centers for Disease Control (CDC) COVID-19 information</a></li>
+<li><a href="https://www.cdc.gov/coronavirus/2019-ncov/specific-groups/guidance-business-response.html?CDC_AA_refVal=https://www.cdc.gov/coronavirus/2019-ncov/guidance-business-response.html" rel="nofollow">CDC guidance for businesses</a></li>
+<li><a href="https://www.cdc.gov/coronavirus/2019-ncov/specific-groups/guidance-for-schools.html" rel="nofollow">CDC guidance for schools and childcare</a></li>
+<li><a href="https://www.cdc.gov/coronavirus/2019-ncov/travelers/index.html" rel="nofollow">CDC guidance for travelers</a></li>
+</ul>
+          </div>
+    <div class="field field-label-hidden field-name-field-right-column field-type-text-long field-items">
+            <ul><li><a href="https://www.cdc.gov/coronavirus/2019-ncov/specific-groups/pregnant-women.html" rel="nofollow">CDC guidance for pregnant women and children</a></li>
+<li><a href="https://www.cdc.gov/coronavirus/2019-ncov/about/share-facts-stop-fear.html">CDC: Share the facts, not the fear</a></li>
+<li><a href="https://www.ada.org/en/publications/ada-news/2020-archive/february/ada-releases-coronavirus-handout-for-dentists-based-on-cdc-guidelines">American Dental Association guidance</a></li>
+</ul>
+          </div>
+
+  </div>
+
+</div>
+
+      
+  </div>
+</div>
+
+              <div class="entity entity-paragraphs-item component-section paragraphs-item-drawer dr contextual-region" bos_context_type="Drawer">
+
+  <input type="checkbox" id="dr--3" class="dr-tr a11y--h">
+
+  <label for="dr--3" class="dr-h">
+
+	  <div class="dr-ic">
+	    <svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 8.5 18 25">
+		    <path class="dr-i" d="M16 21L.5 33.2c-.6.5-1.5.4-2.2-.2-.5-.6-.4-1.6.2-2l12.6-10-12.6-10c-.6-.5-.7-1.5-.2-2s1.5-.7 2.2-.2L16 21z"></path>
+	    </svg>
+    </div>
+
+	  <div class="dr-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        State
+            </div>
+          </div>
+</div>
+
+	    </label>
+
+	<div class="dr-c">
+                <div class="entity entity-paragraphs-item paragraphs-item-text-one-column component-section entity entity-paragraphs-item component-section" bos_context_type="Text One Column" about="" typeof="">
+  <div class="content">
+                <ul><li><a href="https://www.mass.gov/resource/information-on-the-outbreak-of-coronavirus-disease-2019-covid-19">Mass.gov information on coronavirus</a></li>
+<li><a href="http://blog.mass.gov/publichealth/infectious-disease/learn-more-about-the-2019-novel-coronavirus/">Mass. Department of Public Health website</a></li>
+<li><a href="https://www.mass.gov/know-plan-prepare">Mass.gov: Know, plan, and prepare</a></li>
+<li><a href="https://mbta.com/news/2020-03-04/increased-sanitation-schedule-preparedness-planning-coronavirus">MBTA sanitation information for public transit</a></li>
+<li><a href="https://www.boston.gov/node/11564766">Emergency childcare programs</a></li>
+</ul>
+      
+  </div>
+</div>
+
+      
+  </div>
+</div>
+
+              <div class="entity entity-paragraphs-item component-section paragraphs-item-drawer dr contextual-region" bos_context_type="Drawer">
+
+  <input type="checkbox" id="dr--4" class="dr-tr a11y--h">
+
+  <label for="dr--4" class="dr-h">
+
+	  <div class="dr-ic">
+	    <svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 8.5 18 25">
+		    <path class="dr-i" d="M16 21L.5 33.2c-.6.5-1.5.4-2.2-.2-.5-.6-.4-1.6.2-2l12.6-10-12.6-10c-.6-.5-.7-1.5-.2-2s1.5-.7 2.2-.2L16 21z"></path>
+	    </svg>
+    </div>
+
+	  <div class="dr-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        Recovery support services
+            </div>
+          </div>
+</div>
+
+	    </label>
+
+	<div class="dr-c">
+                <div class="entity entity-paragraphs-item paragraphs-item-text-one-column component-section entity entity-paragraphs-item component-section" bos_context_type="Text One Column" about="" typeof="">
+  <div class="content">
+                <address>Alcoholics Anonymous:</address>
+<ul><li><a href="https://www.aaonlinemeeting.net/">AA Online meetings</a></li>
+</ul><address>Narcotics Anonymous:</address>
+<ul><li><a href="https://virtual-na.org/">Virtual NA meetings online</a></li>
+<li><a href="https://na.org/meetingsearch/">NA meeting search</a></li>
+</ul><address>Smart Recovery:</address>
+<ul><li><a href="http://www.smartrecovery.org/smart-recovery-toolbox/smart-recovery-online/">SMART Recovery online community</a></li>
+<li><a href="http://www.smartrecovery.org/private-convenient-online-recovery-support/">Private, convenient, online recovery support</a></li>
+</ul><address>Other resources:</address>
+<ul><li><a href="https://www.addictioncampuses.com/alcohol/apps-for-recovery/">Apps for alcohol addiction recovery</a></li>
+<li><a href="https://www.sobergrid.com/howitworks">Sober Grid app</a></li>
+<li><a href="https://www.intherooms.com/home/">In the Rooms: Global&nbsp;Recovery Community</a></li>
+</ul>
+      
+  </div>
+</div>
+
+      
+  </div>
+</div>
+
+              <div class="entity entity-paragraphs-item component-section paragraphs-item-drawer dr contextual-region" bos_context_type="Drawer">
+
+  <input type="checkbox" id="dr--5" class="dr-tr a11y--h">
+
+  <label for="dr--5" class="dr-h">
+
+	  <div class="dr-ic">
+	    <svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 8.5 18 25">
+		    <path class="dr-i" d="M16 21L.5 33.2c-.6.5-1.5.4-2.2-.2-.5-.6-.4-1.6.2-2l12.6-10-12.6-10c-.6-.5-.7-1.5-.2-2s1.5-.7 2.2-.2L16 21z"></path>
+	    </svg>
+    </div>
+
+	  <div class="dr-t">    <div class="field field-name-field-title field-type-text field-type-string field-label-hidden field-items">
+                <div>
+        Multilingual documents (Shqip - Albanian, فارسی - Farsi, ភាសាខ្មែរ - Khmer-Cambodian))
+            </div>
+          </div>
+</div>
+
+	    </label>
+
+	<div class="dr-c">
+                <div class="entity entity-paragraphs-item paragraphs-item-text-one-column component-section entity entity-paragraphs-item component-section" bos_context_type="Text One Column" about="" typeof="">
+  <div class="content">
+                <ul><li><a href="https://docs.google.com/document/d/1cx4Z_AIUaqJxjrUpzmmwZD89oj1uM1f4OyVSWh3oILs/edit">VENDET E NGRËNIES GJATE GJENDJES SE EMERGJENCES (Shqip - Albanian)</a></li>
+<li><a href="https://www.boston.gov/sites/default/files/file/2020/03/Letter%20from%20mjw%20for%20lit%20drop_Albanian.doc%20%281%29.pdf">Të Dashur Banorë (Shqip - Albanian)</a></li>
+<li><a href="https://www.bphc.org/whatwedo/infectious-diseases/Infectious-Diseases-A-to-Z/Documents/Fact%20Sheet%20Languages/2019%20novel%20coronavirus/Farsi.pdf">Boston Public Health Commission fact sheet (فارسی - Farsi))</a></li>
+<li><a href="https://bphc.org/whatwedo/infectious-diseases/Infectious-Diseases-A-to-Z/Documents/Fact%20Sheet%20Languages/2019%20novel%20coronavirus/Cambodian.pdf">Boston Public Health Commission fact sheet (ភាសាខ្មែរ - Khmer-Cambodian)</a></li>
+</ul>
+      
+  </div>
+</div>
+
+      
+  </div>
+</div>
+
+      
+    </div>
+  </div>
+</div>
+
+                    </div>
+    
+    </div>
+  
+  
+</article>
+
+  
+
+        
+
+      </section>
+    </div>
+  </div>
+  
+<footer class="ft">
+    <div class="ft-c">
+        <ul class="ft-ll ft-ll--r">
+            <li class="ft-ll-i"><a href="http://www.cityofboston.gov/311/" class="ft-ll-a lnk--yellow"><span class="ft-ll-311">BOS:311</span><span class="tablet--hidden"> - </span>Report an issue</a></li>
+        </ul>
+        <nav role="navigation" aria-labelledby="block-footermenu-menu" id="block-footermenu" data-block-plugin-id="menu_block:menu-footer-menu">
+            
+  <h2 class="visually-hidden" id="block-footermenu-menu">Footer menu</h2>
+  
+
+        
+                            <ul class="ft-ll">
+                            <li class="ft-ll-i ft-ll-a">
+                <a href="https://www.boston.gov/departments/innovation-and-technology/terms-use-and-privacy-policy" target="_blank" title="" data-drupal-link-system-path="node/31526">Privacy Policy</a>
+                            </li>
+                    <li class="ft-ll-i ft-ll-a">
+                <a href="https://www.boston.gov/departments/mayors-office/contact-boston-city-hall" title="" data-drupal-link-system-path="node/1806">Contact us</a>
+                            </li>
+                    <li class="ft-ll-i ft-ll-a">
+                <a href="https://www.boston.gov/departments/711/city-boston-alerts-and-notifications" title="" data-drupal-link-system-path="node/31131">Alerts and notifications</a>
+                            </li>
+                    <li class="ft-ll-i ft-ll-a">
+                <a href="https://www.boston.gov/departments/public-records" title="" data-drupal-link-system-path="node/16136">Public records requests</a>
+                            </li>
+                </ul>
+    
+
+
+  </nav>
+
+    </div>
+</footer>
+
+</div>
+
+
+
+
+  </div>
+
+    
+
+    <script id="contactFormTemplate" type="text/x-template">
+    <div class="md">
+        <div class="md-c">
+            <button class="md-cb">Close</button>
+            <div class="mb-b p-a300 p-a600--xl">
+                <div class="sh m-b500">
+                    <div class="sh-title">Contact Us</div>
+                </div>
+                <div>
+                    <div id="contactMessage" class="t--info m-b500">Have a question, or just need help? You can send an email through the form below.</div>
+                    <form id="contactForm" action="https://contactform.boston.gov/emails" method="POST">
+                        <input id="contactFormToAddress" name="email[to_address]" type="hidden" value="">
+                        <input id="contactFormURL" name="email[url]" type="hidden" value="">
+                        <input id="contactFormBrowser" name="email[browser]" type="hidden" value="">
+                        <div class="fs">
+                            <div class="fs-c">
+                                <div class="txt m-b300">
+                                    <label for="contact-name" class="txt-l txt-l--mt000">Full Name</label>
+                                    <input id="contact-name" name="email[name]" type="text" class="txt-f bos-contact-name" size="10" value="">
+                                </div>
+                                <div class="txt m-b300">
+                                    <label for="contact-address" class="txt-l txt-l--mt000">Email Address</label>
+                                    <input id="contact-address" name="email[from_address]" type="text" placeholder="email@address.com" class="txt-f bos-contact-email" value="">
+                                </div>
+                                <div class="txt m-b300">
+                                    <label for="contact-subject" class="txt-l txt-l--mt000">Subject</label>
+                                    <input id="contact-subject" name="email[subject]" type="text" class="txt-f bos-contact-subject" size="10" value="">
+                                </div>
+                                <div class="txt m-b300">
+                                    <label for="contact-message" class="txt-l txt-l--mt000">Message</label>
+                                    <textarea id="contact-message" name="email[message]" type="text" class="txt-f bos-contact-message" rows="10"></textarea>
+                                </div>
+                            </div>
+                            <div class="bc bc--r p-t500">
+                                <button type="submit" class="btn btn--700">Send Message</button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</script>
+
+    <script type="application/json" data-drupal-selector="drupal-settings-json">{"path":{"baseUrl":"\/","scriptPath":null,"pathPrefix":"","currentPath":"node\/11561926","currentPathIsAdmin":false,"isFront":false,"currentLanguage":"en"},"pluralDelimiter":"\u0003","suppressDeprecationErrors":true,"ajaxPageState":{"libraries":"bos_bibblio\/bos_bibblio_css,bos_components\/field.style,bos_theme\/context_link,bos_theme\/fleet-components.patterns,bos_theme\/global-styling.always,bos_theme\/global-styling.patterns,bos_theme\/page.assets,bos_theme\/page.inpage_menu,core\/html5shiv,paragraphs\/drupal.paragraphs.unpublished,poll\/drupal.poll-links,system\/base","theme":"bos_theme","theme_token":null},"ajaxTrustedUrl":[],"ajax":[],"user":{"uid":0,"permissionsHash":"712ef0b5061a59d37cab2f9ca274bac63f7496e8fe8c4c3f94ae3bc247e529fb"}}</script>
+<script src="./CoronavirusDiseaseinBoston.gov_files/js_djFyzoGiK0_fktFV7KoYriGTe-aNHa8elhkPG4Tq2qQ.js"></script>
+<script src="./CoronavirusDiseaseinBoston.gov_files/fleetcomponents.js"></script>
+<script src="./CoronavirusDiseaseinBoston.gov_files/js_WLrNiOdA2IlquH1AQgEMCdwcIkhLnUhr-XPUM2EJCF4.js"></script>
+<script src="./CoronavirusDiseaseinBoston.gov_files/bos_theme.context_menu_link.js" id="bos_theme_context_menu_link"></script>
+<script src="./CoronavirusDiseaseinBoston.gov_files/bos_theme.contextual_toolbar_tab.js" id="bos_core_contextual_toolbar_tab"></script>
+<script src="./CoronavirusDiseaseinBoston.gov_files/inpage_menu.boston.js" id="inpage_menu_script"></script>
+<script src="./CoronavirusDiseaseinBoston.gov_files/messages.boston.js" id="messages_script"></script>
+<script src="./CoronavirusDiseaseinBoston.gov_files/cob_ckeditor.boston.js" id="cob_ckeditor_script"></script>
+
+<!--[if IE 9]>
+<script src="/sites/default/files/js/js_VazMdB7n5VPCNUi7EMTSESLbwkO6VhD4Na_uxRUyHh4.js"></script>
+<![endif]-->
+<script src="./CoronavirusDiseaseinBoston.gov_files/js_i3CdBGUcbCeiVJC_EqAW0xz1stha808_jeLEUBYj6T0.js"></script>
+<script src="./CoronavirusDiseaseinBoston.gov_files/all.js"></script>
+
+  <script type="text/javascript">window.NREUM||(NREUM={});NREUM.info={"beacon":"bam.nr-data.net","licenseKey":"06206dff86","applicationID":"449797348","transactionName":"M1ZQYkVZXRUCARBaDgocc1VDUVwITCYWRhEFX251WEpWOi4HCkY9IFZUV0JURysGDBF\/CApYZkRSXX4HDQsURg0FR11ERBUNAQYMAUEAEFZ7WFNdSycNBjdcExA=","queueTime":0,"applicationTime":244,"atts":"HxFTFA1DThs=","errorBeacon":"bam.nr-data.net","agent":""}</script>
+
+</body></html>

--- a/mycity/mycity/test/unit_tests/test_coronavirus_update_parsing.py
+++ b/mycity/mycity/test/unit_tests/test_coronavirus_update_parsing.py
@@ -1,0 +1,39 @@
+"""
+Test parsing utilities of the CoronavirusUpdateIntent. 
+
+These tests rely on sample data in this repository. If the real
+website changes format, it should be caught by integration
+tests and the sample will need to be updated.
+"""
+
+import mycity.intents.coronavirus_update_intent as coronavirus_update_intent
+import mycity.test.unit_tests.base as base
+
+from bs4 import BeautifulSoup
+import os
+import unittest.mock as mock
+
+
+def _get_test_data_parser(file_name):
+    test_file_path = os.path.join(os.getcwd(),
+                                  "mycity/test/test_data", file_name)
+    with open(test_file_path) as f:
+        parser = BeautifulSoup(f.read(), 'html.parser')
+        return parser
+
+
+class CoronavirusUpdateParserTest(base.BaseTestCase):
+
+    @mock.patch('mycity.intents.coronavirus_update_intent._get_html_parser')
+    def test_boston_homepage_parse(self, mock_get_html_parser):
+        parser = _get_test_data_parser('Boston.gov.html')
+        mock_get_html_parser.return_value = parser
+        output_speech = coronavirus_update_intent._get_homepage_text()
+        self.assertTrue(output_speech)
+
+    @mock.patch('mycity.intents.coronavirus_update_intent._get_html_parser')
+    def test_boston_coronavirus_detail_parse(self, mock_get_html_parser):
+        parser = _get_test_data_parser('CoronavirusDiseaseinBoston.gov.html')
+        mock_get_html_parser.return_value = parser
+        output_speech = coronavirus_update_intent._get_coronavirus_detail_text()
+        self.assertTrue(output_speech)

--- a/mycity/platforms/amazon/models/en_US.json
+++ b/mycity/platforms/amazon/models/en_US.json
@@ -2,6 +2,11 @@
     "interactionModel": {
         "languageModel": {
             "invocationName": "boston info",
+            "modelConfiguration": {
+                "fallbackIntentSensitivity": {
+                    "level": "LOW"
+                }
+            },
             "intents": [
                 {
                     "name": "TrashDayIntent",
@@ -1242,6 +1247,40 @@
                         "farmers markets today",
                         "are there any farmers markets today",
                         "farmers markets"
+                    ]
+                },
+                {
+                    "name": "CoronavirusUpdateIntent",
+                    "slots": [],
+                    "samples": [
+                        "give me the latest coronavirus information",
+                        "give me the latest coronavirus update",
+                        "give me the latest covid information",
+                        "give me the latest covid nineteen information",
+                        "give me the latest covid nineteen update",
+                        "give me the latest covid update",
+                        "give me the latest pandemic information",
+                        "give me the latest pandemic update",
+                        "what is the latest coronavirus information",
+                        "what is the latest coronavirus update",
+                        "what is the latest covid information",
+                        "what is the latest covid nineteen information",
+                        "what is the latest covid nineteen update",
+                        "what is the latest covid update",
+                        "what is the latest pandemic information",
+                        "what is the latest pandemic update",
+                        "coronavirus information",
+                        "coronavirus update",
+                        "covid information",
+                        "covid nineteen information",
+                        "covid nineteen update",
+                        "covid update",
+                        "pandemic information",
+                        "pandemic update",
+                        "whats the latest on coronavirus",
+                        "whats the latest on covid",
+                        "whats the latest on covid nineteen",
+                        "whats the latest on pandemic"
                     ]
                 }
             ],


### PR DESCRIPTION
Adds a new intent to get information from Boston.gov about the coronavirus. This does not yet add a "news sound" as requested in the issue. I will create a new issue for that part of the feature, since it doesn't seem like a strict requirement to get this feature out. 


Closes #315 