### PR TITLE
Implemented choice for alerts for GetAlertsIntent

### DIFF
--- a/mycity/mycity/intents/get_alerts_intent.py
+++ b/mycity/mycity/intents/get_alerts_intent.py
@@ -91,7 +91,7 @@ def get_alerts_intent(
         if 'Decision' in intent_variables \
         and 'value' in intent_variables['Decision'] \
         else None
-    session_alerts = session_alerts['alerts'] \
+    session_alerts = session_attributes['alerts'] \
         if 'alerts' in session_attributes else None
 
     logger.debug('decision: ' + str(decision) +
@@ -129,14 +129,19 @@ def get_alerts_intent(
         mycity_response.should_end_session = False
         mycity_response.output_speech = constants.LAUNCH_REPROMPT_SPEECH
     elif decision == 'all':
-        # TODO: return response of all alerts [end]
-        pass
+        mycity_response.output_speech = \
+            alerts_to_speech_output(session_alerts) \
+            if alerts_to_speech_output_function_for_test is None \
+            else alerts_to_speech_output_function_for_test(session_alerts)
     elif decision in session_alerts:
-        # TODO: return response for selected alert [end]
-        pass
+        alert = { decision: session_alerts[decision] }
+        mycity_response.output_speech = alerts_to_speech_output(alert) \
+            if alerts_to_speech_output_function_for_test is None \
+            else alerts_to_speech_output_function_for_test(alert)
     else:
-        # TODO: return response to remind to decide [continue]
-        pass
+        mycity_response.should_end_session = False
+        mycity_response.output_speech = constants.INVALID_DECISION_SCRIPT
+        mycity_response.output_speech += list_alerts_output(session_alerts)
 
     return mycity_response
 

--- a/mycity/mycity/intents/get_alerts_intent.py
+++ b/mycity/mycity/intents/get_alerts_intent.py
@@ -87,12 +87,9 @@ def get_alerts_intent(
     # get the intent_variables and sessions_attribute object from the request
     intent_variables = mycity_request.intent_variables
     session_attributes = mycity_request.session_attributes
-    decision = intent_variables['Decision']['value'] \
-        if 'Decision' in intent_variables \
-        and 'value' in intent_variables['Decision'] \
-        else None
-    session_alerts = session_attributes['alerts'] \
-        if 'alerts' in session_attributes else None
+    decision = intent_variables['Decision'].get('value') \
+        if 'Decision' in intent_variables else None
+    session_alerts = session_attributes.get('alerts')
 
     logger.debug('decision: ' + str(decision) +
                  ', session_alerts: ' + str(session_alerts))
@@ -257,7 +254,7 @@ def prune_normal_responses(service_alerts: typing.Dict) -> typing.Dict:
         if service.value in service_alerts and \
                 str.find(service_alerts[service.value], "normal") != -1:
             service_alerts.pop(service.value)                       # remove
-    if service_alerts[Services.TOW_LOT.value] == TOW_LOT_NORMAL_MESSAGE:
+    if service_alerts.get(Services.TOW_LOT.value) == TOW_LOT_NORMAL_MESSAGE:
         service_alerts.pop(Services.TOW_LOT.value)
     return service_alerts
 

--- a/mycity/mycity/intents/get_alerts_intent.py
+++ b/mycity/mycity/intents/get_alerts_intent.py
@@ -32,7 +32,7 @@ class Services(Enum):
     """
     Organizes and contains information about all possible alert types
     that are supported in a readable format.
-    
+
     """
     STREET_CLEANING = 'Street Cleaning'
     TRASH = 'Trash and recycling'
@@ -44,7 +44,7 @@ class Services(Enum):
     ALERT_HEADER = 'Alert header'
 
 
-# constants for scraping boston.gov                                                                   
+# constants for scraping boston.gov
 BOSTON_GOV = "https://www.boston.gov"
 SERVICE_NAMES = "cds-t t--upper t--sans m-b300"
 SERVICE_INFO = "cds-d t--subinfo"
@@ -77,27 +77,59 @@ def get_alerts_intent(
     :param get_alerts_function_for_test: Injectable function for unit tests
     :param prune_normal_responses_function_for_test: Injectable function
      for unit tests
-    :param alerts_to_speech_output_function_for_test: Injectable function 
+    :param alerts_to_speech_output_function_for_test: Injectable function
     for unit tests
     :return: MyCityResponseDataModel object
     """
     logger.debug('MyCityRequestDataModel received:' +
                  mycity_request.get_logger_string())
 
-    alerts = get_alerts() if get_alerts_function_for_test is None \
-        else get_alerts_function_for_test()
-    logger.debug("[dictionary with alerts scraped from boston.gov]:\n" +
-                 str(alerts))
+    # get the intent_variables and sessions_attribute object from the request
+    intent_variables = mycity_request.intent_variables
+    session_attributes = mycity_request.session_attributes
 
-    pruned_alerts = prune_normal_responses(alerts) \
-        if prune_normal_responses_function_for_test is None \
-        else prune_normal_responses_function_for_test(alerts)
-    logger.debug("[dictionary after pruning]:\n" + str(alerts))
-
+    # Build the response.
+    #   - if decision was made before asking alert, remind to ask for alert
+    #   - if there is no decision - probably asking for alerts, list alerts
+    #   - if there is decision w/ alerts, get the appropriate alert
     mycity_response = _create_response_object()
-    mycity_response.output_speech = alerts_to_speech_output(pruned_alerts) \
-        if alerts_to_speech_output_function_for_test is None \
-        else alerts_to_speech_output_function_for_test(pruned_alerts)
+    mycity_response.session_attributes = session_attributes.copy()
+
+    if 'Decision' not in intent_variables or \
+            'value' not in intent_variables['Decision']:
+        alerts = get_alerts() if get_alerts_function_for_test is None \
+            else get_alerts_function_for_test()
+        logger.debug("[dictionary with alerts scraped from boston.gov]:\n" +
+                     str(alerts))
+
+        pruned_alerts = prune_normal_responses(alerts) \
+            if prune_normal_responses_function_for_test is None \
+            else prune_normal_responses_function_for_test(alerts)
+        logger.debug("[dictionary after pruning]:\n" + str(pruned_alerts))
+        pruned_alerts = { k.lower(): v for k, v in pruned_alerts.items() }
+
+        if len(pruned_alerts) > 1:
+            mycity_response.session_attributes['alerts'] = pruned_alerts
+            mycity_response.should_end_session = False
+            mycity_response.output_speech = list_alerts_output(pruned_alerts)
+        else:
+            mycity_response.output_speech = \
+                alerts_to_speech_output(pruned_alerts) \
+                if alerts_to_speech_output_function_for_test is None \
+                else alerts_to_speech_output_function_for_test(pruned_alerts)
+    elif 'alerts' not in session_attributes:
+        # TODO: return warning to ask for alerts [continue]
+        pass
+    elif intent_variables['Decision'] == 'all':
+        # TODO: return response of all alerts [end]
+        pass
+    elif intent_variables['Decision'] in session_attributes['alerts']:
+        # TODO: return response for selected alert [end]
+        pass
+    else:
+        # TODO: return response to remind to decide [continue]
+        pass
+
     return mycity_response
 
 
@@ -149,12 +181,32 @@ def _create_response_object() -> MyCityResponseDataModel:
     return mycity_response
 
 
+def list_alerts_output(alerts: typing.Dict) -> typing.AnyStr:
+    """
+    Output list of alerts to pick for when there's multiple alerts.
+
+    :param alerts: pruned alert dictionary
+    :return: a string containing all alerts to decide on.
+    """
+    logger.debug('alerts: ' + str(alerts))
+    alert_count = len(alerts)
+    alert_list = ""
+    for i, alert in enumerate(alerts.keys()):
+        if i + 1 == alert_count:
+            alert_list += 'and '
+        alert_list += alert.capitalize()
+        if i + 1 < alert_count:
+            alert_list += ', '
+    alert_list = alert_list.strip()
+    return constants.ALERT_LISTING_SCRIPT.format(alert_count, alert_list)
+
+
 def alerts_to_speech_output(alerts: typing.Dict) -> typing.AnyStr:
     """
     Checks whether the alert dictionary contains any entries. Returns a string
     that contains all alerts or a message that city services are operating
     normally.
-    
+
     :param alerts: pruned alert dictionary
     :return: a string containing all alerts, or if no alerts are
         found, a message indicating there are no alerts at this time
@@ -170,14 +222,14 @@ def alerts_to_speech_output(alerts: typing.Dict) -> typing.AnyStr:
         return constants.NO_ALERTS
     else:
         return all_alerts.rstrip()
-        
+
 
 def prune_normal_responses(service_alerts: typing.Dict) -> typing.Dict:
     """
     Remove any text scraped from Boston.gov that aren't actually alerts.
-    For example, parking meters, city building hours, and trash and 
+    For example, parking meters, city building hours, and trash and
     recycling are described "as on a normal schedule"
-    
+
     :param service_alerts: raw alerts dictionary, potentially with unrelated
         non-alert data
     :return: pruned alert dictionary containing only the current
@@ -186,7 +238,7 @@ def prune_normal_responses(service_alerts: typing.Dict) -> typing.Dict:
     logger.debug('service_alerts: ' + str(service_alerts))
 
 
-    # for any defined service, if its alert is that it's running normally, 
+    # for any defined service, if its alert is that it's running normally,
     # remove it from the dictionary
     for service in Services:
         if service.value in service_alerts and \
@@ -201,7 +253,7 @@ def get_alerts():
     """
     Checks Boston.gov for alerts, and if present scrapes them and returns
     them as a dictionary
-    
+
     :return: a dictionary that maps alert names to detailed alert message
     """
     logger.debug('')
@@ -230,4 +282,3 @@ def get_alerts():
     if header != '':
         alerts[Services.ALERT_HEADER.value] = header.rstrip()
     return alerts
-

--- a/mycity/mycity/intents/speech_constants/get_alerts_intent.py
+++ b/mycity/mycity/intents/speech_constants/get_alerts_intent.py
@@ -6,6 +6,8 @@ Speech utterances for get_alerts_intent.py
 NO_ALERTS = "There are no alerts. City services are running on normal schedules."
 NO_INCLEMENT_WEATHER_ALERTS = "There are no weather related alerts"
 
+LAUNCH_REPROMPT_SPEECH = "You can also ask about the locations of " \
+    "food trucks and farmer's markets, or info about snow emergencies. " \
+    "If you have feedback for the skill say 'I have a suggestion'."
 ALERT_LISTING_SCRIPT = "There are {} current alerts affecting the following " \
-                       "services: {}. Which one would you like to hear about? " \
-                       "Or pick 'all'."
+    "services: {}. Which one would you like to hear about? Or pick 'all'."

--- a/mycity/mycity/intents/speech_constants/get_alerts_intent.py
+++ b/mycity/mycity/intents/speech_constants/get_alerts_intent.py
@@ -11,3 +11,4 @@ LAUNCH_REPROMPT_SPEECH = "You can also ask about the locations of " \
     "If you have feedback for the skill say 'I have a suggestion'."
 ALERT_LISTING_SCRIPT = "There are {} current alerts affecting the following " \
     "services: {}. Which one would you like to hear about? Or pick 'all'."
+INVALID_DECISION_SCRIPT = "Sorry, I didn't understand that. "

--- a/mycity/mycity/intents/speech_constants/get_alerts_intent.py
+++ b/mycity/mycity/intents/speech_constants/get_alerts_intent.py
@@ -5,3 +5,7 @@ Speech utterances for get_alerts_intent.py
 
 NO_ALERTS = "There are no alerts. City services are running on normal schedules."
 NO_INCLEMENT_WEATHER_ALERTS = "There are no weather related alerts"
+
+ALERT_LISTING_SCRIPT = "There are {} current alerts affecting the following " \
+                       "services: {}. Which one would you like to hear about? " \
+                       "Or pick 'all'."

--- a/mycity/mycity/test/integration_tests/test_get_alerts.py
+++ b/mycity/mycity/test/integration_tests/test_get_alerts.py
@@ -39,18 +39,16 @@ class GetAlertsTestCase(mix_ins.RepromptTextTestMixIn,
         self.mock_get_alerts.stop()
         self.mock_get_alerts = None
 
-    # these tests required patches to pass tests...not sure why    
+    # these tests required patches to pass tests...not sure why
     @mock.patch('mycity.intents.get_alerts_intent.get_alerts',
                 return_value=no_alerts.copy())
     def test_response_with_no_alerts(self, mock_get_alerts):
         response = self.controller.on_intent(self.request)
         expected_response = get_alerts_speech_constants.NO_ALERTS
         self.assertEqual(response.output_speech, expected_response)
-        
+
     @mock.patch('mycity.intents.get_alerts_intent.get_alerts',
                 return_value=some_alerts.copy())
     def test_response_with_alerts(self, mock_get_alerts):
         response = self.controller.on_intent(self.request)
         self.assertIn('Godzilla inbound!', response.output_speech)
-
-

--- a/mycity/mycity/test/test_constants.py
+++ b/mycity/mycity/test/test_constants.py
@@ -831,7 +831,8 @@ GET_ALERTS_MOCK_ONE_ALERT = {
 }
 
 GET_ALERTS_MOCK_SOME_ALERTS = {
-    'Tow lot': 'Tow lots destroyed!', 'Parking meters': 'Parking meters are all broken.',
+    'Tow lot': 'Tow lots destroyed!',
+    'Parking meters': 'Parking meters are all broken.',
     'City building hours': 'Stay away from city buildings.',
     'Trash and recycling': 'Pickup is on a normal schedule.',
     'Street Cleaning': 'Street cleaning is canceled',

--- a/mycity/mycity/test/test_constants.py
+++ b/mycity/mycity/test/test_constants.py
@@ -821,6 +821,15 @@ GET_ALERTS_MOCK_NO_ALERTS = {
     'Trash and recycling': 'Pickup is on a normal schedule.'
 }
 
+GET_ALERTS_MOCK_ONE_ALERT = {
+    'Alert header': 'Godzilla inbound!',
+    'City building hours': 'All municipal buildings are open based on their normal hours.',
+    'Parking meters': 'Parking meters are running on their normal schedules today.',
+    'Street Cleaning': 'Today is the first Thursday of the month and street cleaning is running on a normal schedule.',
+    'Tow lot': 'The tow lot is open from 7 a.m. - 11 p.m. Automated kiosks are available 24 hours a day, seven days a week for vehicle releases.',
+    'Trash and recycling': 'Pickup is on a normal schedule.'
+}
+
 GET_ALERTS_MOCK_SOME_ALERTS = {
     'Tow lot': 'Tow lots destroyed!', 'Parking meters': 'Parking meters are all broken.',
     'City building hours': 'Stay away from city buildings.',

--- a/mycity/platforms/amazon/models/en_US.json
+++ b/mycity/platforms/amazon/models/en_US.json
@@ -1,7 +1,7 @@
 {
     "interactionModel": {
         "languageModel": {
-            "invocationName": "boston info",
+            "invocationName": "boston debug",
             "modelConfiguration": {
                 "fallbackIntentSensitivity": {
                     "level": "LOW"
@@ -1027,8 +1027,14 @@
                 },
                 {
                     "name": "GetAlertsIntent",
-                    "slots": [],
+                    "slots": [
+                        {
+                            "name": "Decision",
+                            "type": "BostonServices"
+                        }
+                    ],
                     "samples": [
+                        "{Decision}",
                         "what the current status",
                         "give me the city status",
                         "give me all alerts",
@@ -1284,7 +1290,113 @@
                     ]
                 }
             ],
-            "types": []
+            "types": [
+                {
+                    "name": "BostonServices",
+                    "values": [
+                        {
+                            "name": {
+                                "value": "all"
+                            }
+                        },
+                        {
+                            "name": {
+                                "value": "city construction",
+                                "synonyms": [
+                                    "constructions",
+                                    "city constructions",
+                                    "construction"
+                                ]
+                            }
+                        },
+                        {
+                            "name": {
+                                "value": "restaurants and bars",
+                                "synonyms": [
+                                    "bar",
+                                    "bars",
+                                    "restaurant",
+                                    "restaurants"
+                                ]
+                            }
+                        },
+                        {
+                            "name": {
+                                "value": "meal sites for youth",
+                                "synonyms": [
+                                    "male site for youth",
+                                    "youth meal site",
+                                    "meal site",
+                                    "youth meal sites",
+                                    "meal sites"
+                                ]
+                            }
+                        },
+                        {
+                            "name": {
+                                "value": "tow lot",
+                                "synonyms": [
+                                    "lot",
+                                    "tow"
+                                ]
+                            }
+                        },
+                        {
+                            "name": {
+                                "value": "parking meters",
+                                "synonyms": [
+                                    "parking",
+                                    "meters"
+                                ]
+                            }
+                        },
+                        {
+                            "name": {
+                                "value": "street cleaning"
+                            }
+                        },
+                        {
+                            "name": {
+                                "value": "trash and recycling",
+                                "synonyms": [
+                                    "recycling",
+                                    "trash"
+                                ]
+                            }
+                        },
+                        {
+                            "name": {
+                                "value": "status of city departments",
+                                "synonyms": [
+                                    "city status",
+                                    "city departments status",
+                                    "city departments"
+                                ]
+                            }
+                        },
+                        {
+                            "name": {
+                                "value": "city building hours",
+                                "synonyms": [
+                                    "building hours",
+                                    "city hours",
+                                    "city building"
+                                ]
+                            }
+                        },
+                        {
+                            "name": {
+                                "value": "schools closed",
+                                "synonyms": [
+                                    "school closings",
+                                    "school closing",
+                                    "school closed"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
         },
         "dialog": {
             "intents": [

--- a/mycity/platforms/amazon/models/en_US.json
+++ b/mycity/platforms/amazon/models/en_US.json
@@ -1,7 +1,7 @@
 {
     "interactionModel": {
         "languageModel": {
-            "invocationName": "boston debug",
+            "invocationName": "boston info",
             "modelConfiguration": {
                 "fallbackIntentSensitivity": {
                     "level": "LOW"


### PR DESCRIPTION
I got around breaking up the long list of alerts to be selectable if there is more than one alert. This is a critical enhancement to address issue #316.

This requires a major refactoring on the `get_alerts_intent.py` to allow decisions and listing of alerts in session attributes. I also included a slue of tests that practically covered the entire `get_alerts_intent` function. Personally, the implementation seems a bit too verbose with the implementation and if you think it needs further refactoring, let me know.

And on the Alexa side of things, I have to create a new list slot type named `BostonServices` for the specific Boston services, and I felt like this might need to be managed down the line for occasional updates.

Other than that, let me know if there are other things I should address before approving.