### PR TITLE
Update interaction model for default utterance

### DIFF
--- a/skill-package/interactionModels/custom/en-US.json
+++ b/skill-package/interactionModels/custom/en-US.json
@@ -1059,7 +1059,7 @@
             }
           ],
           "samples": [
-            "{Decision}",
+            "city service alerts",
             "what the current status",
             "give me the city status",
             "give me all alerts",


### PR DESCRIPTION
This adds the utterance in the welcome speech to the city alert utterance list. Bug reported by Andre from CoB